### PR TITLE
feat: CI workflow 추가

### DIFF
--- a/.github/workflows/ci-back.yml
+++ b/.github/workflows/ci-back.yml
@@ -1,0 +1,48 @@
+name: ci-back
+
+on:
+  pull_request:
+    branches:
+      - dev
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository checkout
+        uses: actions/checkout@v3
+
+      - name: install java 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: assign grant gradlew
+        run: chmod +x gradlew
+
+      - name: test gradle
+        run: ./gradlew --info test
+
+      - name: Publish Test Results   
+        uses: EnricoMi/publish-unit-test-result-action@v2     
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: Publish Test Report
+        uses: mikepenz/action-junit-report@v4
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'


### PR DESCRIPTION
## 관련 이슈
close: #3 

## PR 세부 내용
PR 등록 시 CI를 수행하는 workflow 입니다.

`dev`, `main` 브랜치가 base 대상이 되면 작업을 수행합니다.

실행 환경은 `ubuntu`를 사용합니다.
자바 버전은 `17`을 사용하고,  `Cache Gradle packages` job을 통해 캐싱을 수행하여 실행 시간을 단축시켰습니다.