### PR TITLE
feat: API 명세를 정의, 문서를 제작 (#7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Docs ###
+/src/main/resources/static/docs/*

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,7 +28,7 @@ repositories {
 
 val asciidoctorExt = "asciidoctorExt"
 configurations.create(asciidoctorExt) {
-    extendsFrom(configurations["testImplementation"])
+    extendsFrom(configurations.testImplementation.get())
 }
 
 val snippetsDir = file("build/generated-snippets")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,6 +53,8 @@ dependencies {
     // https://mvnrepository.com/artifact/com.github.f4b6a3/ulid-creator
     implementation("com.github.f4b6a3:ulid-creator:5.2.2")
     asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
+
+    implementation("io.github.oshai:kotlin-logging-jvm:5.1.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,8 +26,12 @@ repositories {
     mavenCentral()
 }
 
-val asciidoctorExt: Configuration by configurations.creating
-val snippetsDir by extra { file("build/generated-snippets") }
+val asciidoctorExt = "asciidoctorExt"
+configurations.create(asciidoctorExt) {
+    extendsFrom(configurations["testImplementation"])
+}
+
+val snippetsDir = file("build/generated-snippets")
 
 dependencies {
     implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
@@ -64,22 +68,19 @@ tasks.withType<KotlinCompile> {
     }
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
-}
-
 tasks.test {
     outputs.dir(snippetsDir)
+    useJUnitPlatform()
 }
 
 tasks.asciidoctor {
     inputs.dir(snippetsDir)
     dependsOn(tasks.test)
-    configurations("asciidoctorExt")
+    configurations(asciidoctorExt)
     baseDirFollowsSourceFile()
 }
 
-tasks.register("copyDocument", Copy::class) {
+val copyDocument = tasks.register<Copy>("copyDocument") {
     dependsOn(tasks.asciidoctor)
     doFirst {
         delete(file("src/main/resources/static/docs"))
@@ -89,15 +90,15 @@ tasks.register("copyDocument", Copy::class) {
 }
 
 tasks.build {
-    dependsOn(tasks.getByName("copyDocument"))
+    dependsOn(copyDocument)
 }
 
 tasks.bootJar {
-    dependsOn(tasks.getByName("copyDocument"))
+    dependsOn(copyDocument)
 }
 
 allOpen {
     annotation("jakarta.persistence.Entity")
-    annotation ("jakarta.persistence.Embeddable")
-    annotation ("jakarta.persistence.MappedSuperclass")
+    annotation("jakarta.persistence.Embeddable")
+    annotation("jakarta.persistence.MappedSuperclass")
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,6 +26,7 @@ repositories {
     mavenCentral()
 }
 
+val asciidoctorExt: Configuration by configurations.creating
 val snippetsDir by extra { file("build/generated-snippets") }
 
 dependencies {
@@ -51,6 +52,7 @@ dependencies {
 
     // https://mvnrepository.com/artifact/com.github.f4b6a3/ulid-creator
     implementation("com.github.f4b6a3:ulid-creator:5.2.2")
+    asciidoctorExt("org.springframework.restdocs:spring-restdocs-asciidoctor")
 }
 
 tasks.withType<KotlinCompile> {
@@ -71,6 +73,25 @@ tasks.test {
 tasks.asciidoctor {
     inputs.dir(snippetsDir)
     dependsOn(tasks.test)
+    configurations("asciidoctorExt")
+    baseDirFollowsSourceFile()
+}
+
+tasks.register("copyDocument", Copy::class) {
+    dependsOn(tasks.asciidoctor)
+    doFirst {
+        delete(file("src/main/resources/static/docs"))
+    }
+    from(file("build/docs/asciidoc"))
+    into(file("src/main/resources/static/docs"))
+}
+
+tasks.build {
+    dependsOn(tasks.getByName("copyDocument"))
+}
+
+tasks.bootJar {
+    dependsOn(tasks.getByName("copyDocument"))
 }
 
 allOpen {

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,7 @@
+= Star Citizen Korean Translation Project - API Docs
+:doctype: book
+:toc: left
+:source-highlighter: highlightjs
+:sectlinks:
+
+include::news-api.adoc[]

--- a/src/docs/asciidoc/news-api.adoc
+++ b/src/docs/asciidoc/news-api.adoc
@@ -1,0 +1,29 @@
+[[news-api]]
+== 뉴스
+
+[[news-create]]
+=== 뉴스 생성
+*요청*
+include::{snippets}/news/create/http-request.adoc[]
+include::{snippets}/news/create/request-fields.adoc[]
+*응답*
+include::{snippets}/news/create/http-response.adoc[]
+include::{snippets}/news/create/response-fields.adoc[]
+
+[[news-find-all]]
+=== 뉴스 전체 조회
+*요청*
+include::{snippets}/news/find-all/http-request.adoc[]
+*응답*
+include::{snippets}/news/find-all/http-response.adoc[]
+include::{snippets}/news/find-all/response-fields.adoc[]
+
+[[news-find-detail]]
+=== 뉴스 상세 조회
+*요청*
+include::{snippets}/news/find-detail/http-request.adoc[]
+include::{snippets}/news/find-detail/path-parameters.adoc[]
+include::{snippets}/news/find-detail/query-parameters.adoc[]
+*응답*
+include::{snippets}/news/find-detail/http-response.adoc[]
+include::{snippets}/news/find-detail/response-fields.adoc[]

--- a/src/main/kotlin/kr/galaxyhub/sc/api/common/ApiResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/common/ApiResponse.kt
@@ -1,0 +1,22 @@
+package kr.galaxyhub.sc.api.common
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonInclude.Include
+
+@JsonInclude(Include.NON_NULL)
+class ApiResponse<T>(
+    val message: String? = null,
+    val data: T
+) {
+
+    companion object {
+
+        fun error(message: String): ApiResponse<Unit> {
+            return ApiResponse(message, Unit)
+        }
+
+        fun <T> success(data: T): ApiResponse<T> {
+            return ApiResponse(data = data)
+        }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/api/common/ApiResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/common/ApiResponse.kt
@@ -6,7 +6,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include
 @JsonInclude(Include.NON_NULL)
 class ApiResponse<T>(
     val message: String? = null,
-    val data: T
+    val data: T,
 ) {
 
     companion object {

--- a/src/main/kotlin/kr/galaxyhub/sc/api/common/ExceptionHandler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/common/ExceptionHandler.kt
@@ -1,0 +1,63 @@
+package kr.galaxyhub.sc.api.common
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.servlet.http.HttpServletRequest
+import kr.galaxyhub.sc.common.exception.GalaxyhubException
+import kr.galaxyhub.sc.common.support.LogLevel
+import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.MissingServletRequestParameterException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.context.request.WebRequest
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler
+
+private val log = KotlinLogging.logger {}
+
+@RestControllerAdvice
+class ExceptionHandler : ResponseEntityExceptionHandler() {
+
+    override fun handleMissingServletRequestParameter(
+        ex: MissingServletRequestParameterException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        return ResponseEntity(
+            ApiResponse("쿼리 파라미터에 누락된 값이 있습니다.", ex.missingParameters()),
+            HttpStatus.BAD_REQUEST
+        )
+    }
+
+    private fun MissingServletRequestParameterException.missingParameters(): String {
+        return this.detailMessageArguments.contentToString()
+    }
+
+    @ExceptionHandler(GalaxyhubException::class)
+    fun handleGalaxyhubException(
+        e: GalaxyhubException,
+        request: HttpServletRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        when (e.logLevel) {
+            LogLevel.ERROR -> log.error(e) { "[🔴ERROR] - (${request.method} ${request.requestURI})" }
+            LogLevel.WARN -> log.warn(e) { "[🟠WARN] - (${request.method} ${request.requestURI})" }
+            LogLevel.INFO -> log.warn(e) { "[🔵INFO] - (${request.method} ${request.requestURI})" }
+            LogLevel.DEBUG -> log.debug(e) { "[🟢DEBUG] - (${request.method} ${request.requestURI})" }
+        }
+        return ResponseEntity(ApiResponse.error(e.message!!), e.httpStatus)
+    }
+
+    @ExceptionHandler(Exception::class)
+    fun handleException(e: Exception, request: HttpServletRequest): ResponseEntity<ApiResponse<Unit>> {
+        log.error(e) { "[🔴ERROR] - (${request.method} ${request.requestURI})" }
+        return ResponseEntity(DEFAULT_ERROR, HttpStatus.INTERNAL_SERVER_ERROR)
+    }
+
+    companion object {
+
+        private val DEFAULT_ERROR = ApiResponse.error("서버 내부에 알 수 없는 문제가 발생했습니다.")
+    }
+}
+

--- a/src/main/kotlin/kr/galaxyhub/sc/api/news/v1/NewsControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/news/v1/NewsControllerV1.kt
@@ -26,7 +26,7 @@ class NewsControllerV1(
 ) {
 
     @GetMapping
-    fun findAll():ResponseEntity<ApiResponse<List<NewsResponse>>> {
+    fun findAll(): ResponseEntity<ApiResponse<List<NewsResponse>>> {
         val response = newsQueryService.findAll()
         return ResponseEntity.ok()
             .body(ApiResponse.success(response))
@@ -35,7 +35,7 @@ class NewsControllerV1(
     @GetMapping("/{id}")
     fun findDetailById(
         @PathVariable id: UUID,
-        @RequestParam language: Language
+        @RequestParam language: Language,
     ): ResponseEntity<ApiResponse<NewsDetailResponse>> {
         val response = newsQueryService.getDetailByIdAndLanguage(id, language)
         return ResponseEntity.ok()

--- a/src/main/kotlin/kr/galaxyhub/sc/api/news/v1/NewsControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/news/v1/NewsControllerV1.kt
@@ -1,0 +1,53 @@
+package kr.galaxyhub.sc.api.news.v1
+
+import java.util.UUID
+import kr.galaxyhub.sc.api.common.ApiResponse
+import kr.galaxyhub.sc.api.news.v1.dto.NewsCreateRequest
+import kr.galaxyhub.sc.common.support.toUri
+import kr.galaxyhub.sc.news.application.NewsCommandService
+import kr.galaxyhub.sc.news.application.NewsQueryService
+import kr.galaxyhub.sc.news.application.dto.NewsDetailResponse
+import kr.galaxyhub.sc.news.application.dto.NewsResponse
+import kr.galaxyhub.sc.news.domain.Language
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/news")
+class NewsControllerV1(
+    private val newsCommandService: NewsCommandService,
+    private val newsQueryService: NewsQueryService,
+) {
+
+    @GetMapping
+    fun findAll():ResponseEntity<ApiResponse<List<NewsResponse>>> {
+        val response = newsQueryService.findAll()
+        return ResponseEntity.ok()
+            .body(ApiResponse.success(response))
+    }
+
+    @GetMapping("/{id}")
+    fun findDetailById(
+        @PathVariable id: UUID,
+        @RequestParam language: Language
+    ): ResponseEntity<ApiResponse<NewsDetailResponse>> {
+        val response = newsQueryService.getDetailByIdAndLanguage(id, language)
+        return ResponseEntity.ok()
+            .body(ApiResponse.success(response))
+    }
+
+    @PostMapping
+    fun create(
+        @RequestBody request: NewsCreateRequest,
+    ): ResponseEntity<ApiResponse<UUID>> {
+        val id = newsCommandService.create(request.toCommand())
+        return ResponseEntity.created("/api/v1/news/${id}".toUri())
+            .body(ApiResponse.success(id))
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/api/news/v1/dto/NewsCreateRequest.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/news/v1/dto/NewsCreateRequest.kt
@@ -1,0 +1,29 @@
+package kr.galaxyhub.sc.api.news.v1.dto
+
+import java.time.ZonedDateTime
+import kr.galaxyhub.sc.news.application.NewsCreateCommand
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.NewsType
+
+data class NewsCreateRequest(
+    val newsType: NewsType,
+    val title: String,
+    val excerpt: String?,
+    val publishedAt: ZonedDateTime,
+    val originId: Long,
+    val originUrl: String,
+    val language: Language,
+    val content: String,
+) {
+
+    fun toCommand() = NewsCreateCommand(
+        newsType = newsType,
+        title = title,
+        excerpt = excerpt,
+        publishedAt = publishedAt,
+        originId = originId,
+        originUrl = originUrl,
+        language = language,
+        content = content
+    )
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1.kt
@@ -1,8 +1,8 @@
-package kr.galaxyhub.sc.api.news.v1
+package kr.galaxyhub.sc.api.v1.news
 
 import java.util.UUID
 import kr.galaxyhub.sc.api.common.ApiResponse
-import kr.galaxyhub.sc.api.news.v1.dto.NewsCreateRequest
+import kr.galaxyhub.sc.api.v1.news.dto.NewsCreateRequest
 import kr.galaxyhub.sc.common.support.toUri
 import kr.galaxyhub.sc.news.application.NewsCommandService
 import kr.galaxyhub.sc.news.application.NewsQueryService

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/dto/NewsCreateRequest.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/dto/NewsCreateRequest.kt
@@ -1,4 +1,4 @@
-package kr.galaxyhub.sc.api.news.v1.dto
+package kr.galaxyhub.sc.api.v1.news.dto
 
 import java.time.ZonedDateTime
 import kr.galaxyhub.sc.news.application.NewsCreateCommand

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/BadRequestException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/BadRequestException.kt
@@ -1,0 +1,11 @@
+package kr.galaxyhub.sc.common.exception
+
+import kr.galaxyhub.sc.common.support.LogLevel
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+
+class BadRequestException(
+    message: String,
+    httpStatus: HttpStatusCode = HttpStatus.BAD_REQUEST,
+    logLevel: LogLevel = LogLevel.INFO,
+) : GalaxyhubException(message, httpStatus, logLevel)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/GalaxyhubException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/GalaxyhubException.kt
@@ -1,0 +1,10 @@
+package kr.galaxyhub.sc.common.exception
+
+import kr.galaxyhub.sc.common.support.LogLevel
+import org.springframework.http.HttpStatusCode
+
+open class GalaxyhubException(
+    message: String,
+    val httpStatus: HttpStatusCode,
+    val logLevel: LogLevel,
+) : RuntimeException(message)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/NotFoundException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/NotFoundException.kt
@@ -1,0 +1,11 @@
+package kr.galaxyhub.sc.common.exception
+
+import kr.galaxyhub.sc.common.support.LogLevel
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+
+class NotFoundException(
+    message: String,
+    httpStatus: HttpStatusCode = HttpStatus.NOT_FOUND,
+    logLevel: LogLevel = LogLevel.DEBUG,
+) : GalaxyhubException(message, httpStatus, logLevel)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/support/CustomPreconditions.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/support/CustomPreconditions.kt
@@ -1,0 +1,10 @@
+package kr.galaxyhub.sc.common.support
+
+import kr.galaxyhub.sc.common.exception.BadRequestException
+
+inline fun validate(value: Boolean, lazyMessage: () -> Any) {
+    if (value) {
+        val message = lazyMessage()
+        throw BadRequestException(message.toString())
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/common/support/LogLevel.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/support/LogLevel.kt
@@ -1,0 +1,9 @@
+package kr.galaxyhub.sc.common.support
+
+enum class LogLevel {
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    ;
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/common/support/StringToUri.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/support/StringToUri.kt
@@ -1,0 +1,5 @@
+package kr.galaxyhub.sc.common.support
+
+import java.net.URI
+
+fun String.toUri(): URI = URI.create(this)

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsCommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsCommandService.kt
@@ -1,0 +1,55 @@
+package kr.galaxyhub.sc.news.application
+
+import java.time.ZonedDateTime
+import java.util.UUID
+import kr.galaxyhub.sc.news.domain.Content
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.News
+import kr.galaxyhub.sc.news.domain.NewsInformation
+import kr.galaxyhub.sc.news.domain.NewsRepository
+import kr.galaxyhub.sc.news.domain.NewsType
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class NewsCommandService(
+    private val newsRepository: NewsRepository,
+) {
+
+    fun create(command: NewsCreateCommand): UUID {
+        val news = newsRepository.findByOriginId(command.originId) ?: newsRepository.save(command.toNews())
+        val content = createContent(news, command)
+        news.addContent(content)
+        return news.id
+    }
+
+    private fun createContent(news: News, command: NewsCreateCommand) = Content(
+        news = news,
+        language = command.language,
+        content = command.content,
+        newsInformation = NewsInformation(
+            title = command.title,
+            excerpt = command.excerpt
+        ),
+    )
+}
+
+data class NewsCreateCommand(
+    val newsType: NewsType,
+    val title: String,
+    val excerpt: String?,
+    val publishedAt: ZonedDateTime,
+    val originId: Long,
+    val originUrl: String,
+    val language: Language,
+    val content: String,
+) {
+
+    fun toNews() = News(
+        newsType = newsType,
+        publishedAt = publishedAt,
+        originId = originId,
+        originUrl = originUrl
+    )
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsQueryService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsQueryService.kt
@@ -1,0 +1,30 @@
+package kr.galaxyhub.sc.news.application
+
+import java.util.UUID
+import kr.galaxyhub.sc.news.application.dto.NewsDetailResponse
+import kr.galaxyhub.sc.news.application.dto.NewsResponse
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.NewsRepository
+import kr.galaxyhub.sc.news.domain.getByDetailByIdAndLanguage
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class NewsQueryService(
+    private val newsRepository: NewsRepository,
+) {
+
+    fun findAll(): List<NewsResponse> {
+        return newsRepository.findAll()
+            .map { NewsResponse.from(it) }
+    }
+
+    fun getDetailByIdAndLanguage(id: UUID, language: Language): NewsDetailResponse {
+        return newsRepository.getByDetailByIdAndLanguage(id, language)
+            .let {
+                val content = it.getContentByLanguage(language)
+                NewsDetailResponse.of(it, content)
+            }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/dto/NewsDetailResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/dto/NewsDetailResponse.kt
@@ -1,0 +1,38 @@
+package kr.galaxyhub.sc.news.application.dto
+
+import java.time.ZonedDateTime
+import java.util.UUID
+import kr.galaxyhub.sc.news.domain.Content
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.News
+import kr.galaxyhub.sc.news.domain.NewsType
+
+data class NewsDetailResponse(
+    val id: UUID,
+    val newsType: NewsType,
+    val title: String?,
+    val excerpt: String?,
+    val publishedAt: ZonedDateTime,
+    val originId: Long,
+    val originUrl: String,
+    val language: Language,
+    val content: String,
+    val supportLanguages: Set<Language>,
+) {
+
+    companion object {
+
+        fun of(news: News, content: Content) = NewsDetailResponse(
+            id = news.id,
+            newsType = news.newsType,
+            publishedAt = news.publishedAt,
+            supportLanguages = news.supportLanguages,
+            originId = news.originId,
+            originUrl = news.originUrl,
+            title = content.newsInformation.title,
+            excerpt = content.newsInformation.excerpt,
+            language = content.language,
+            content = content.content,
+        )
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/dto/NewsResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/dto/NewsResponse.kt
@@ -1,0 +1,33 @@
+package kr.galaxyhub.sc.news.application.dto
+
+import java.time.ZonedDateTime
+import java.util.UUID
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.News
+import kr.galaxyhub.sc.news.domain.NewsType
+
+data class NewsResponse(
+    val id: UUID,
+    val newsType: NewsType,
+    val title: String?,
+    val excerpt: String?,
+    val publishedAt: ZonedDateTime,
+    val supportLanguages: Set<Language>,
+    val originId: Long,
+    val originUrl: String
+) {
+
+    companion object {
+
+        fun from(news: News) = NewsResponse(
+            id = news.id,
+            newsType = news.newsType,
+            title = news.newsInformation.title,
+            excerpt = news.newsInformation.excerpt,
+            publishedAt = news.publishedAt,
+            supportLanguages = news.supportLanguages,
+            originId = news.originId,
+            originUrl = news.originUrl,
+        )
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/dto/NewsResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/dto/NewsResponse.kt
@@ -14,7 +14,7 @@ data class NewsResponse(
     val publishedAt: ZonedDateTime,
     val supportLanguages: Set<Language>,
     val originId: Long,
-    val originUrl: String
+    val originUrl: String,
 ) {
 
     companion object {

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/News.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/News.kt
@@ -12,6 +12,8 @@ import jakarta.persistence.OneToMany
 import java.time.ZonedDateTime
 import java.util.EnumSet
 import kr.galaxyhub.sc.common.domain.PrimaryKeyEntity
+import kr.galaxyhub.sc.common.exception.NotFoundException
+import kr.galaxyhub.sc.common.support.validate
 
 @Entity
 class News(
@@ -60,11 +62,12 @@ class News(
     }
 
     private fun validateAddContent(content: Content) {
-        if (content.news != this) {
-            throw IllegalArgumentException("컨텐츠에 등록된 뉴스가 동일하지 않습니다.") // TODO 명확한 예외 정의할 것
-        }
-        if (mutableSupportLanguages.contains(content.language)) {
-            throw IllegalArgumentException("이미 해당 언어로 작성된 뉴스가 있습니다.") // TODO 명확한 예외 정의할 것
-        }
+        validate(content.news != this) { "컨텐츠에 등록된 뉴스가 동일하지 않습니다." }
+        validate(mutableSupportLanguages.contains(content.language)) { "이미 해당 언어로 작성된 뉴스가 있습니다." }
+    }
+
+    fun getContentByLanguage(language: Language): Content {
+        return contents.find { it.language == language }
+            ?: throw NotFoundException("해당 언어의 컨텐츠가 존재하지 않습니다.")
     }
 }

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsInformation.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsInformation.kt
@@ -9,8 +9,9 @@ data class NewsInformation(
     val title: String?,
 
     @Column(name = "excerpt", nullable = true)
-    val excerpt: String?
+    val excerpt: String?,
 ) {
+
     companion object {
 
         val EMPTY = NewsInformation(null, null)

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsRepository.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsRepository.kt
@@ -1,0 +1,31 @@
+package kr.galaxyhub.sc.news.domain
+
+import java.util.UUID
+import kr.galaxyhub.sc.common.exception.NotFoundException
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.Repository
+import org.springframework.data.repository.query.Param
+
+fun NewsRepository.getByDetailByIdAndLanguage(id: UUID, language: Language) = findFetchByIdAndLanguage(id, language)
+    ?: throw NotFoundException("식별자와 언어에 대한 뉴스를 찾을 수 없습니다. id=${id}, language=${language}")
+
+interface NewsRepository : Repository<News, UUID> {
+
+    fun save(news: News): News
+
+    fun findAll(): List<News>
+
+    fun findByOriginId(originId: Long): News?
+
+    fun findById(id: UUID): News?
+
+    @Query(
+        """
+        select n
+        from News n
+        inner join fetch n.contents nc 
+        where n.id = :id and nc.language = :language
+    """
+    )
+    fun findFetchByIdAndLanguage(@Param("id") id: UUID, @Param("language") language: Language): News?
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/api/news/v1/NewsControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/news/v1/NewsControllerV1Test.kt
@@ -1,0 +1,180 @@
+package kr.galaxyhub.sc.api.news.v1
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import java.util.UUID
+import kr.galaxyhub.sc.api.news.v1.dto.NewsCreateRequest
+import kr.galaxyhub.sc.api.support.ARRAY
+import kr.galaxyhub.sc.api.support.ENUM
+import kr.galaxyhub.sc.api.support.NUMBER
+import kr.galaxyhub.sc.api.support.OBJECT
+import kr.galaxyhub.sc.api.support.STRING
+import kr.galaxyhub.sc.api.support.ZONEDDATETIME
+import kr.galaxyhub.sc.api.support.andDocument
+import kr.galaxyhub.sc.api.support.docGet
+import kr.galaxyhub.sc.api.support.docPost
+import kr.galaxyhub.sc.api.support.param
+import kr.galaxyhub.sc.api.support.pathMeans
+import kr.galaxyhub.sc.api.support.type
+import kr.galaxyhub.sc.news.application.NewsCommandService
+import kr.galaxyhub.sc.news.application.NewsQueryService
+import kr.galaxyhub.sc.news.application.dto.NewsDetailResponse
+import kr.galaxyhub.sc.news.application.dto.NewsResponse
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.NewsType
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(NewsControllerV1::class)
+@AutoConfigureRestDocs
+class NewsControllerV1Test(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+    @MockkBean
+    private val newsQueryService: NewsQueryService,
+    @MockkBean
+    private val newsCommandService: NewsCommandService,
+) : DescribeSpec({
+
+    describe("GET /api/v1/news/{id}") {
+        context("유효한 요청이 전달되면") {
+            it("200 응답과 뉴스의 상세 정보가 조회된다.") {
+                // given
+                val id = UUID.randomUUID()
+                val response = newsDetailResponse(id)
+                every { newsQueryService.getDetailByIdAndLanguage(id, Language.ENGLISH) } returns response
+
+                // when & then
+                mockMvc.docGet("/api/v1/news/{id}", id) {
+                    contentType = MediaType.APPLICATION_JSON
+                    param("language" to Language.ENGLISH)
+                }.andExpect {
+                    status { isOk() }
+                }.andDocument("news/find-detail") {
+                    pathParameters(
+                        "id" pathMeans "뉴스 식별자" constraint "UUID"
+                    )
+                    queryParameters(
+                        "language" pathMeans "뉴스 언어" formattedAs ENUM(Language::class)
+                    )
+                    responseBody(
+                        "data" type OBJECT means "뉴스 상세 정보",
+                        "data.id" type STRING means "뉴스 식별자",
+                        "data.newsType" type ENUM(NewsType::class) means "뉴스 타입",
+                        "data.title" type STRING means "뉴스 제목",
+                        "data.excerpt" type STRING means "뉴스 발췌",
+                        "data.language" type ENUM(Language::class) means "뉴스 언어",
+                        "data.publishedAt" type ZONEDDATETIME means "뉴스 발행 시간",
+                        "data.content" type STRING means "뉴스 내용",
+                        "data.supportLanguages" type ARRAY means "뉴스 지원 언어",
+                        "data.originId" type NUMBER means "원본 뉴스 식별자",
+                        "data.originUrl" type STRING means "원본 뉴스의 URL",
+                    )
+                }
+            }
+        }
+    }
+
+    describe("GET /api/v1/news") {
+        context("유효한 요청이 전달되면") {
+            it("200 응답과 모든 뉴스의 정보가 조회된다.") {
+                // given
+                val response = listOf(newsResponse())
+                every { newsQueryService.findAll() } returns response
+
+                // when & then
+                mockMvc.docGet("/api/v1/news") {
+                    contentType = MediaType.APPLICATION_JSON
+                }.andExpect {
+                    status { isOk() }
+                }.andDocument("news/find-all") {
+                    responseBody(
+                        "data" type ARRAY means "뉴스 목록",
+                        "data[0].id" type STRING means "뉴스 식별자",
+                        "data[0].newsType" type ENUM(NewsType::class) means "뉴스 타입",
+                        "data[0].title" type STRING means "뉴스 제목",
+                        "data[0].excerpt" type STRING means "뉴스 발췌",
+                        "data[0].publishedAt" type ZONEDDATETIME means "뉴스 발행 시간",
+                        "data[0].supportLanguages" type ARRAY means "뉴스 지원 언어",
+                        "data[0].originId" type NUMBER means "원본 뉴스 식별자",
+                        "data[0].originUrl" type STRING means "원본 뉴스의 URL",
+                    )
+                }
+            }
+        }
+    }
+
+    describe("POST /api/v1/news") {
+        context("유효한 요청이 전달되면") {
+            it("201 응답과 뉴스의 식별자가 반환된다.") {
+                // given
+                val request = newsCreateRequest()
+                every { newsCommandService.create(any()) } returns UUID.randomUUID()
+
+                // when & then
+                mockMvc.docPost("/api/v1/news") {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(request)
+                }.andExpect {
+                    status { isCreated() }
+                }.andDocument("news/create") {
+                    requestBody(
+                        "newsType" type ENUM(NewsType::class) means "뉴스 타입",
+                        "title" type STRING means "뉴스 제목",
+                        "excerpt" type STRING means "뉴스 발췌",
+                        "publishedAt" type ZONEDDATETIME means "뉴스 발행 시간",
+                        "originId" type NUMBER means "원본 뉴스 식별자",
+                        "originUrl" type STRING means "원본 뉴스의 URL",
+                        "language" type ENUM(Language::class) means "뉴스 언어",
+                        "content" type STRING means "뉴스 내용"
+                    )
+                    responseBody(
+                        "data" type STRING means "생성한 뉴스의 식별자"
+                    )
+                }
+            }
+        }
+    }
+})
+
+private fun newsCreateRequest() = NewsCreateRequest(
+    newsType = NewsType.NEWS,
+    title = "Star Citizen Live",
+    excerpt = "You asked. We're answering! Join us today for a live Q&A show with the Vehicle Gameplay team.",
+    publishedAt = ZonedDateTime.of(LocalDateTime.parse("2023-12-04T03:53:33"), ZoneId.systemDefault()),
+    originId = 1,
+    originUrl = "https://sc.galaxyhub.kr/",
+    language = Language.KOREAN,
+    content = "어쩌구 저쩌구"
+)
+
+private fun newsDetailResponse(id: UUID) = NewsDetailResponse(
+    id = id,
+    newsType = NewsType.NEWS,
+    title = "Star Citizen Live",
+    excerpt = "You asked. We're answering! Join us today for a live Q&A show with the Vehicle Gameplay team.",
+    language = Language.ENGLISH,
+    publishedAt = ZonedDateTime.of(LocalDateTime.parse("2023-12-09T11:49:44"), ZoneId.systemDefault()),
+    content = "blah blah",
+    originId = 1,
+    originUrl = "https://sc.galaxyhub.kr/",
+    supportLanguages = setOf(Language.ENGLISH)
+)
+
+private fun newsResponse() = NewsResponse(
+    id = UUID.randomUUID(),
+    newsType = NewsType.NEWS,
+    title = "Star Citizen Live",
+    excerpt = "You asked. We're answering! Join us today for a live Q&A show with the Vehicle Gameplay team.",
+    publishedAt = ZonedDateTime.of(LocalDateTime.parse("2023-12-09T11:49:44"), ZoneId.systemDefault()),
+    originId = 1,
+    originUrl = "https://sc.galaxyhub.kr/",
+    supportLanguages = setOf(Language.ENGLISH)
+)

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/DocField.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/DocField.kt
@@ -54,7 +54,7 @@ private fun createField(
         .fieldWithPath(value)
         .type(type)
         .description("")
-        .attributes(*RestDocsUtils.getAllEmptyFormats())
+        .attributes(*RestDocsUtils.getAllEmptyAttributes())
     return DocField(descriptor)
 }
 

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/DocField.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/DocField.kt
@@ -1,0 +1,60 @@
+package kr.galaxyhub.sc.api.support
+
+import org.springframework.restdocs.payload.FieldDescriptor
+import org.springframework.restdocs.payload.JsonFieldType
+import org.springframework.restdocs.payload.PayloadDocumentation
+
+open class DocField(
+    val descriptor: FieldDescriptor,
+) {
+
+    infix fun isOptional(value: Boolean): DocField {
+        if (value) descriptor.optional()
+        return this
+    }
+
+    infix fun means(value: String): DocField {
+        descriptor.description(value)
+        return this
+    }
+
+    infix fun constraint(value: String): DocField {
+        descriptor.attributes(RestDocsUtils.constraint(value))
+        return this
+    }
+
+    infix fun formattedAs(value: String): DocField {
+        descriptor.attributes(RestDocsUtils.format(value))
+        return this
+    }
+}
+
+infix fun <T : Enum<T>> String.type(enumFieldType: ENUM<T>): DocField {
+    val field = createField(this, JsonFieldType.STRING)
+    field formattedAs enumFieldType.enums.joinToString(separator = ", ")
+    return field
+}
+
+infix fun String.type(docsFieldType: DocsFieldType): DocField {
+    val field = createField(this, docsFieldType.type)
+    when (docsFieldType) {
+        is DATE -> field formattedAs DATE.DEFAULT_FORMAT
+        is DATETIME -> field formattedAs DATETIME.DEFAULT_FORMAT
+        is ZONEDDATETIME -> field formattedAs ZONEDDATETIME.DEFAULT_FORMAT
+        else -> {}
+    }
+    return field
+}
+
+private fun createField(
+    value: String,
+    type: JsonFieldType,
+): DocField {
+    val descriptor = PayloadDocumentation
+        .fieldWithPath(value)
+        .type(type)
+        .description("")
+        .attributes(*RestDocsUtils.getAllEmptyFormats())
+    return DocField(descriptor)
+}
+

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/DocFieldType.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/DocFieldType.kt
@@ -1,0 +1,28 @@
+package kr.galaxyhub.sc.api.support
+
+import kotlin.reflect.KClass
+import org.springframework.restdocs.payload.JsonFieldType
+
+sealed class DocsFieldType(
+    val type: JsonFieldType,
+)
+
+data object ARRAY : DocsFieldType(JsonFieldType.ARRAY)
+data object BOOLEAN : DocsFieldType(JsonFieldType.BOOLEAN)
+data object OBJECT : DocsFieldType(JsonFieldType.OBJECT)
+data object NUMBER : DocsFieldType(JsonFieldType.NUMBER)
+data object NULL : DocsFieldType(JsonFieldType.NULL)
+data object STRING : DocsFieldType(JsonFieldType.STRING)
+data object ANY : DocsFieldType(JsonFieldType.VARIES)
+data object DATE : DocsFieldType(JsonFieldType.STRING) {
+    const val DEFAULT_FORMAT = "2023-12-11"
+}
+data object DATETIME : DocsFieldType(JsonFieldType.STRING) {
+    const val DEFAULT_FORMAT = "2023-12-11T10:15:30"
+}
+data object ZONEDDATETIME : DocsFieldType(JsonFieldType.STRING) {
+    const val DEFAULT_FORMAT = "2023-12-11T10:15:30+09:00"
+}
+data class ENUM<T : Enum<T>>(val enums: Collection<T>) : DocsFieldType(JsonFieldType.STRING) {
+    constructor(clazz: KClass<T>) : this(clazz.java.enumConstants.asList())
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/DocParam.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/DocParam.kt
@@ -1,0 +1,43 @@
+package kr.galaxyhub.sc.api.support
+
+import org.springframework.restdocs.request.ParameterDescriptor
+import org.springframework.restdocs.request.RequestDocumentation
+
+open class DocParam(
+    val descriptor: ParameterDescriptor,
+) {
+
+    infix fun isOptional(value: Boolean): DocParam {
+        if (value) descriptor.optional()
+        return this
+    }
+
+    infix fun constraint(value: String): DocParam {
+        descriptor.attributes(RestDocsUtils.constraint(value))
+        return this
+    }
+
+    infix fun formattedAs(value: String): DocParam {
+        descriptor.attributes(RestDocsUtils.format(value))
+        return this
+    }
+
+    infix fun <T : Enum<T>> formattedAs(enumFieldType: ENUM<T>): DocParam {
+        return formattedAs(enumFieldType.enums.joinToString(separator = ", "))
+    }
+}
+
+infix fun String.pathMeans(description: String): DocParam {
+    return createField(this, description)
+}
+
+private fun createField(
+    value: String,
+    description: String,
+): DocParam {
+    val descriptor = RequestDocumentation
+        .parameterWithName(value)
+        .description(description)
+        .attributes(*RestDocsUtils.getAllEmptyFormats())
+    return DocParam(descriptor)
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/DocParam.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/DocParam.kt
@@ -38,6 +38,6 @@ private fun createField(
     val descriptor = RequestDocumentation
         .parameterWithName(value)
         .description(description)
-        .attributes(*RestDocsUtils.getAllEmptyFormats())
+        .attributes(*RestDocsUtils.getAllEmptyAttributes())
     return DocParam(descriptor)
 }

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/MockMvcDsl.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/MockMvcDsl.kt
@@ -1,0 +1,205 @@
+package kr.galaxyhub.sc.api.support
+
+import org.springframework.http.HttpMethod
+import org.springframework.restdocs.generate.RestDocumentationGenerator
+import org.springframework.test.web.servlet.MockHttpServletRequestDsl
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.ResultActionsDsl
+import org.springframework.test.web.servlet.delete
+import org.springframework.test.web.servlet.get
+import org.springframework.test.web.servlet.head
+import org.springframework.test.web.servlet.multipart
+import org.springframework.test.web.servlet.options
+import org.springframework.test.web.servlet.patch
+import org.springframework.test.web.servlet.post
+import org.springframework.test.web.servlet.put
+import org.springframework.test.web.servlet.request
+
+
+/**
+ * https://github.com/Ninja-Squad/spring-rest-docs-kotlin
+ */
+
+/**
+ * Create a [ResultActionsDsl] for a GET request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.get] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docGet(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return get(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a POST request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.post] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docPost(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return post(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a PUT request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.put] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docPut(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return put(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a DELETE request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.delete] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docDelete(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return delete(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a HEAD request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.head] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docHead(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return head(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+
+/**
+ * Create a [ResultActionsDsl] for an OPTIONS request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.options] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docOptions(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return options(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a PATCH request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.patch] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docPatch(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return patch(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a multipart request. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.multipart] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docMultipart(
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return multipart(urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+/**
+ * Create a [ResultActionsDsl] for a request with the given HTTP method. The URL template
+ * will be captured and made available for documentation.
+ * Use this method instead of [MockMvc.multipart] in order to be able to document the URL template and path parameters
+ * @param urlTemplate a URL template; the resulting URL will be encoded
+ * @param urlVariables zero or more URL variables
+ * @return the DSL allowing to apply expectations, handlers, and to document the request
+ */
+fun MockMvc.docRequest(
+    method: HttpMethod,
+    urlTemplate: String,
+    vararg urlVariables: Any?,
+    dsl: MockHttpServletRequestDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return request(method, urlTemplate, *urlVariables) {
+        requestAttr(RestDocumentationGenerator.ATTRIBUTE_NAME_URL_TEMPLATE, urlTemplate);
+        dsl()
+    }
+}
+
+fun MockHttpServletRequestDsl.param(pair: Pair<String, Any>) {
+    this.param(pair.first, pair.second.toString())
+}
+
+fun ResultActionsDsl.andDocument(
+    identifier: String,
+    dsl: RestDocDsl.() -> Unit = {}
+): ResultActionsDsl {
+    return RestDocDsl().apply(dsl).perform(identifier, this)
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocDsl.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocDsl.kt
@@ -38,7 +38,7 @@ class RestDocDsl {
         queryParametersSnippet = RequestDocumentation.queryParameters(params.map { it.descriptor })
     }
 
-    internal fun perform(identifier: String, resultActionDsl: ResultActionsDsl): ResultActionsDsl {
+    fun perform(identifier: String, resultActionDsl: ResultActionsDsl): ResultActionsDsl {
         return resultActionDsl.andDo {
             handle(
                 MockMvcRestDocumentation.document(

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocDsl.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocDsl.kt
@@ -1,0 +1,70 @@
+package kr.galaxyhub.sc.api.support
+
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.operation.preprocess.OperationRequestPreprocessor
+import org.springframework.restdocs.operation.preprocess.OperationResponsePreprocessor
+import org.springframework.restdocs.operation.preprocess.Preprocessors
+import org.springframework.restdocs.payload.PayloadDocumentation
+import org.springframework.restdocs.payload.RequestFieldsSnippet
+import org.springframework.restdocs.payload.ResponseFieldsSnippet
+import org.springframework.restdocs.request.PathParametersSnippet
+import org.springframework.restdocs.request.QueryParametersSnippet
+import org.springframework.restdocs.request.RequestDocumentation
+import org.springframework.test.web.servlet.ResultActionsDsl
+
+class RestDocDsl {
+
+    private var pathParametersSnippet: PathParametersSnippet? = null
+
+    private var requestFieldsSnippet: RequestFieldsSnippet? = null
+
+    private var responseFieldsSnippet: ResponseFieldsSnippet? = null
+
+    private var queryParametersSnippet: QueryParametersSnippet? = null
+
+    fun pathParameters(vararg params: DocParam) {
+        pathParametersSnippet = RequestDocumentation.pathParameters(params.map { it.descriptor })
+    }
+
+    fun requestBody(vararg fields: DocField) {
+        requestFieldsSnippet = PayloadDocumentation.requestFields(fields.map { it.descriptor })
+    }
+
+    fun responseBody(vararg fields: DocField) {
+        responseFieldsSnippet = PayloadDocumentation.responseFields(fields.map { it.descriptor })
+    }
+
+    fun queryParameters(vararg params: DocParam) {
+        queryParametersSnippet = RequestDocumentation.queryParameters(params.map { it.descriptor })
+    }
+
+    internal fun perform(identifier: String, resultActionDsl: ResultActionsDsl): ResultActionsDsl {
+        return resultActionDsl.andDo {
+            handle(
+                MockMvcRestDocumentation.document(
+                    identifier,
+                    preprocessRequest,
+                    preprocessResponse,
+                    *listOfNotNull(
+                        pathParametersSnippet,
+                        requestFieldsSnippet,
+                        responseFieldsSnippet,
+                        queryParametersSnippet
+                    ).toTypedArray()
+                )
+            )
+        }
+    }
+
+    companion object {
+
+        val preprocessRequest: OperationRequestPreprocessor = Preprocessors.preprocessRequest(
+            Preprocessors.prettyPrint(),
+        )
+
+        val preprocessResponse: OperationResponsePreprocessor = Preprocessors.preprocessResponse(
+            Preprocessors.prettyPrint(),
+        )
+    }
+}
+

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocsUtils.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocsUtils.kt
@@ -19,7 +19,7 @@ class RestDocsUtils {
 
         fun constraint(value: String): Attributes.Attribute = CONSTRAINT_BUILDER.value(value)
 
-        fun getAllEmptyFormats(): Array<Attributes.Attribute> {
+        fun getAllEmptyAttributes(): Array<Attributes.Attribute> {
             return arrayOf(EMPTY_FORMAT, EMPTY_CONSTRAINT)
         }
     }

--- a/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocsUtils.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/support/RestDocsUtils.kt
@@ -1,0 +1,26 @@
+package kr.galaxyhub.sc.api.support
+
+import org.springframework.restdocs.snippet.Attributes
+
+class RestDocsUtils {
+
+    companion object {
+
+        private val EMPTY_FORMAT = Attributes.key("format").value("")
+        private val EMPTY_CONSTRAINT = Attributes.key("constraint").value("")
+        private val FORMAT_BUILDER = Attributes.key("format")
+        private val CONSTRAINT_BUILDER = Attributes.key("constraint")
+
+        fun emptyFormat(): Attributes.Attribute = EMPTY_FORMAT
+
+        fun format(value: String): Attributes.Attribute = FORMAT_BUILDER.value(value)
+
+        fun emptyConstraint(): Attributes.Attribute = EMPTY_CONSTRAINT
+
+        fun constraint(value: String): Attributes.Attribute = CONSTRAINT_BUILDER.value(value)
+
+        fun getAllEmptyFormats(): Array<Attributes.Attribute> {
+            return arrayOf(EMPTY_FORMAT, EMPTY_CONSTRAINT)
+        }
+    }
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
@@ -1,4 +1,4 @@
-package kr.galaxyhub.sc.api.news.v1
+package kr.galaxyhub.sc.api.v1.news
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.ninjasquad.springmockk.MockkBean
@@ -8,7 +8,7 @@ import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import java.util.UUID
-import kr.galaxyhub.sc.api.news.v1.dto.NewsCreateRequest
+import kr.galaxyhub.sc.api.v1.news.dto.NewsCreateRequest
 import kr.galaxyhub.sc.api.support.ARRAY
 import kr.galaxyhub.sc.api.support.ENUM
 import kr.galaxyhub.sc.api.support.NUMBER

--- a/src/test/kotlin/kr/galaxyhub/sc/config/KotestProjectConfig.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/KotestProjectConfig.kt
@@ -1,0 +1,9 @@
+package kr.galaxyhub.sc.config
+
+import io.kotest.core.config.AbstractProjectConfig
+import io.kotest.extensions.spring.SpringExtension
+
+class KotestProjectConfig : AbstractProjectConfig() {
+
+    override fun extensions() = listOf(SpringExtension)
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/news/application/NewsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/news/application/NewsCommandServiceTest.kt
@@ -1,0 +1,73 @@
+package kr.galaxyhub.sc.news.application
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldNotBe
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.ZonedDateTime
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.MemoryNewsRepository
+import kr.galaxyhub.sc.news.domain.NewsType
+
+class NewsCommandServiceTest(
+    private val newsRepository: MemoryNewsRepository = MemoryNewsRepository(),
+    private val newsCommandService: NewsCommandService = NewsCommandService(newsRepository),
+) : DescribeSpec({
+
+    beforeContainer { newsRepository.clear() }
+
+    describe("create") {
+        context("originId에 대해 저장된 뉴스가 없으면") {
+            it("새로운 뉴스가 생성된다.") {
+                // given
+                val command = newsCreateCommand()
+
+                // when
+                val id = withContext(Dispatchers.IO) {
+                    newsCommandService.create(command)
+                }
+
+                // then
+                val news = newsRepository.findById(id)!!
+                news shouldNotBe null
+                news.supportLanguages shouldContainExactly setOf(Language.KOREAN)
+            }
+        }
+
+        context("originId에 대해 저장된 뉴스가 있으면") {
+            it("기존 뉴스에 새로운 언어에 대한 컨텐츠가 추가된다.") {
+                // given
+                val existsCommand = newsCreateCommand()
+                withContext(Dispatchers.IO) {
+                    newsCommandService.create(existsCommand)
+                }
+
+                // when
+                val command = existsCommand.copy(language = Language.ENGLISH)
+                val id = withContext(Dispatchers.IO) {
+                    newsCommandService.create(command)
+                }
+
+                // then
+                val news = newsRepository.findById(id)!!
+                news.supportLanguages shouldContainExactly setOf(Language.KOREAN, Language.ENGLISH)
+                newsRepository.findAll() shouldHaveSize 1
+            }
+        }
+    }
+})
+
+private fun newsCreateCommand() = NewsCreateCommand(
+    newsType = NewsType.NEWS,
+    title = "제목",
+    excerpt = "줄거리",
+    publishedAt = ZonedDateTime.of(LocalDateTime.parse("2023-12-04T03:53:33"), ZoneId.systemDefault()),
+    originId = 1,
+    originUrl = "https://sc.galaxyhub.kr/",
+    language = Language.KOREAN,
+    content = "내용"
+)

--- a/src/test/kotlin/kr/galaxyhub/sc/news/domain/MemoryNewsRepository.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/news/domain/MemoryNewsRepository.kt
@@ -1,0 +1,25 @@
+package kr.galaxyhub.sc.news.domain
+
+import java.util.UUID
+
+class MemoryNewsRepository(
+    private val memory: MutableMap<UUID, News> = mutableMapOf(),
+) : NewsRepository {
+
+    fun clear() = memory.clear()
+
+    override fun save(news: News): News {
+        memory[news.id] = news
+        return news
+    }
+
+    override fun findAll(): List<News> = memory.values.toList()
+
+    override fun findByOriginId(originId: Long): News? = memory.values.firstOrNull { it.originId == originId }
+
+    override fun findById(id: UUID): News? = memory[id]
+
+    override fun findFetchByIdAndLanguage(id: UUID, language: Language): News? {
+        return memory[id]?.takeIf { it.supportLanguages.contains(language) }
+    }
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/news/domain/NewsTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/news/domain/NewsTest.kt
@@ -8,6 +8,7 @@ import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kr.galaxyhub.sc.common.exception.BadRequestException
 import kr.galaxyhub.sc.news.fixture.ContentFixture
 import kr.galaxyhub.sc.news.fixture.NewsFixture
 
@@ -37,8 +38,8 @@ class NewsTest : DescribeSpec({
             val otherNews = NewsFixture.create()
             val content = ContentFixture.from(Language.ENGLISH, otherNews)
 
-            it("IllegalArgumentException 예외를 던진다.") {
-                val exception = shouldThrow<IllegalArgumentException> {
+            it("BadRequestException 예외를 던진다.") {
+                val exception = shouldThrow<BadRequestException> {
                     news.addContent(content)
                 }
                 exception shouldHaveMessage "컨텐츠에 등록된 뉴스가 동일하지 않습니다."
@@ -52,8 +53,8 @@ class NewsTest : DescribeSpec({
 
             news.addContent(englishContent)
 
-            it("IllegalArgumentException 예외를 던진다.") {
-                val exception = shouldThrow<IllegalArgumentException> {
+            it("BadRequestException 예외를 던진다.") {
+                val exception = shouldThrow<BadRequestException> {
                     news.addContent(otherEnglishContent)
                 }
                 exception shouldHaveMessage "이미 해당 언어로 작성된 뉴스가 있습니다."

--- a/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/path-parameters.snippet
@@ -1,0 +1,12 @@
+
+==== Path Parameters
+|===
+|파라미터|설명|필수여부|제약조건
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}{{/optional}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraint}}{{constraint}}{{/constraint}}{{^constraint}}{{/constraint}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/query-parameters.snippet
@@ -1,0 +1,13 @@
+
+==== Query Parameters
+|===
+|파라미터|설명|필수여부|제약조건|형식
+
+{{#parameters}}
+|{{#tableCellContent}}`+{{name}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}{{/optional}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraint}}{{constraint}}{{/constraint}}{{^constraint}}{{/constraint}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{format}}{{/format}}{{^format}}{{/format}}{{/tableCellContent}}
+{{/parameters}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,14 @@
+
+==== Request Fields
+|===
+|필드명|타입|필수여부|설명|제약조건|형식
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}{{/optional}}{{^optional}}true{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#constraint}}{{constraint}}{{/constraint}}{{^constraint}}{{/constraint}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{format}}{{/format}}{{^format}}{{/format}}{{/tableCellContent}}
+{{/fields}}
+|===

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,11 @@
+
+==== Response Fields
+|===
+|필드명|타입|설명
+
+{{#fields}}
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+{{/fields}}
+|===


### PR DESCRIPTION
## 관련 이슈
close #7

## PR 세부 내용
News API 명세와 Spring REST Docs를 사용하여 문서화를 하였습니다.
서버 실행 후 `/docs/index.html`로 접속하면 API 문서 볼 수 있습니다.
그 전에 Gradle을 통해 `documentation-asciidoctor` Task 실행하셔야 합니다..! (혹은 build)

예외 명세는 API 문서에 나와있지 않습니다.
지금은 단순히 `message` 필드를 통해 어떤 예외가 발생했는지 알려주고 있습니다.
추후 회의를 통해 예외 명세를 어떻게 할 지 정의해야 할 것 같네요. (`ErrorCode`와 같은 값 등)

코드가 긴 관계로 세부적인 사항은 커맨트를 통해 설명 남기겠습니다.

