### PR TITLE
fix: News 컬럼 nullable 제약 수정, API 문서 필수 여부 수정 (#14)

### DIFF
--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsInformation.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsInformation.kt
@@ -5,8 +5,8 @@ import jakarta.persistence.Embeddable
 
 @Embeddable
 data class NewsInformation(
-    @Column(name = "title", nullable = true)
-    val title: String?,
+    @Column(name = "title", nullable = false)
+    val title: String,
 
     @Column(name = "excerpt", nullable = true)
     val excerpt: String?,
@@ -14,7 +14,7 @@ data class NewsInformation(
 
     companion object {
 
-        val EMPTY = NewsInformation(null, null)
+        val EMPTY = NewsInformation("", null)
     }
 }
 

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
@@ -128,7 +128,7 @@ class NewsControllerV1Test(
                     requestBody(
                         "newsType" type ENUM(NewsType::class) means "뉴스 타입",
                         "title" type STRING means "뉴스 제목",
-                        "excerpt" type STRING means "뉴스 발췌",
+                        "excerpt" type STRING means "뉴스 발췌" isOptional true,
                         "publishedAt" type ZONEDDATETIME means "뉴스 발행 시간",
                         "originId" type NUMBER means "원본 뉴스 식별자",
                         "originUrl" type STRING means "원본 뉴스의 URL",


### PR DESCRIPTION
## 관련 이슈

close: #14 

## PR 세부 내용

News 컬럼의 title을 nullable 하지 않도록 변경했습니다.
또한, API 문서에 뉴스 생성 시 `excerpt` 필드가 필수로 되어 있으므로 해당 사항을 수정합니다.