### PR TITLE
test: 테스트 코드 given-when-then 주석 삭제 및 테스트 가독성 개선 (#22)

### DIFF
--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
@@ -45,13 +45,11 @@ class NewsControllerV1Test(
 
     describe("GET /api/v1/news/{id}") {
         context("유효한 요청이 전달되면") {
-            it("200 응답과 뉴스의 상세 정보가 조회된다.") {
-                // given
-                val id = UUID.randomUUID()
-                val response = newsDetailResponse(id)
-                every { newsQueryService.getDetailByIdAndLanguage(id, Language.ENGLISH) } returns response
+            val id = UUID.randomUUID()
+            val response = newsDetailResponse(id)
+            every { newsQueryService.getDetailByIdAndLanguage(id, Language.ENGLISH) } returns response
 
-                // when & then
+            it("200 응답과 뉴스의 상세 정보가 조회된다.") {
                 mockMvc.docGet("/api/v1/news/{id}", id) {
                     contentType = MediaType.APPLICATION_JSON
                     param("language" to Language.ENGLISH)
@@ -84,12 +82,10 @@ class NewsControllerV1Test(
 
     describe("GET /api/v1/news") {
         context("유효한 요청이 전달되면") {
-            it("200 응답과 모든 뉴스의 정보가 조회된다.") {
-                // given
-                val response = listOf(newsResponse())
-                every { newsQueryService.findAll() } returns response
+            val response = listOf(newsResponse())
+            every { newsQueryService.findAll() } returns response
 
-                // when & then
+            it("200 응답과 모든 뉴스의 정보가 조회된다.") {
                 mockMvc.docGet("/api/v1/news") {
                     contentType = MediaType.APPLICATION_JSON
                 }.andExpect {
@@ -113,12 +109,10 @@ class NewsControllerV1Test(
 
     describe("POST /api/v1/news") {
         context("유효한 요청이 전달되면") {
-            it("201 응답과 뉴스의 식별자가 반환된다.") {
-                // given
-                val request = newsCreateRequest()
-                every { newsCommandService.create(any()) } returns UUID.randomUUID()
+            val request = newsCreateRequest()
+            every { newsCommandService.create(any()) } returns UUID.randomUUID()
 
-                // when & then
+            it("201 응답과 뉴스의 식별자가 반환된다.") {
                 mockMvc.docPost("/api/v1/news") {
                     contentType = MediaType.APPLICATION_JSON
                     content = objectMapper.writeValueAsString(request)

--- a/src/test/kotlin/kr/galaxyhub/sc/news/application/NewsCommandServiceTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/news/application/NewsCommandServiceTest.kt
@@ -23,37 +23,31 @@ class NewsCommandServiceTest(
     describe("create") {
         context("originId에 대해 저장된 뉴스가 없으면") {
             it("새로운 뉴스가 생성된다.") {
-                // given
-                val command = newsCreateCommand()
-
-                // when
-                val id = withContext(Dispatchers.IO) {
-                    newsCommandService.create(command)
+                val originId = 1L
+                val newsId = withContext(Dispatchers.IO) {
+                    newsCommandService.create(newsCreateCommand(originId))
                 }
 
-                // then
-                val news = newsRepository.findById(id)!!
+                val news = newsRepository.findById(newsId)!!
                 news shouldNotBe null
                 news.supportLanguages shouldContainExactly setOf(Language.KOREAN)
             }
         }
 
         context("originId에 대해 저장된 뉴스가 있으면") {
-            it("기존 뉴스에 새로운 언어에 대한 컨텐츠가 추가된다.") {
-                // given
-                val existsCommand = newsCreateCommand()
-                withContext(Dispatchers.IO) {
-                    newsCommandService.create(existsCommand)
-                }
+            val originId = 1L
+            val existsCommand = newsCreateCommand(originId)
+            withContext(Dispatchers.IO) {
+                newsCommandService.create(existsCommand)
+            }
 
-                // when
+            it("기존 뉴스에 새로운 언어에 대한 컨텐츠가 추가된다.") {
                 val command = existsCommand.copy(language = Language.ENGLISH)
-                val id = withContext(Dispatchers.IO) {
+                val newsId = withContext(Dispatchers.IO) {
                     newsCommandService.create(command)
                 }
 
-                // then
-                val news = newsRepository.findById(id)!!
+                val news = newsRepository.findById(newsId)!!
                 news.supportLanguages shouldContainExactly setOf(Language.KOREAN, Language.ENGLISH)
                 newsRepository.findAll() shouldHaveSize 1
             }
@@ -61,12 +55,12 @@ class NewsCommandServiceTest(
     }
 })
 
-private fun newsCreateCommand() = NewsCreateCommand(
+private fun newsCreateCommand(originId: Long) = NewsCreateCommand(
     newsType = NewsType.NEWS,
     title = "제목",
     excerpt = "줄거리",
     publishedAt = ZonedDateTime.of(LocalDateTime.parse("2023-12-04T03:53:33"), ZoneId.systemDefault()),
-    originId = 1,
+    originId = originId,
     originUrl = "https://sc.galaxyhub.kr/",
     language = Language.KOREAN,
     content = "내용"


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #22 

## PR 세부 내용

이슈에 남긴 내용과 더불어 `NewsCommandServiceTest`의 가독성을 개선하였습니다.
