### PR TITLE
feat: Flyway DDL 파일 추가 (#11)

### DIFF
--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/Content.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/Content.kt
@@ -10,7 +10,6 @@ import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
 import jakarta.persistence.JoinColumn
-import jakarta.persistence.Lob
 import jakarta.persistence.ManyToOne
 
 @Entity
@@ -35,11 +34,10 @@ class Content(
         protected set
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "language", nullable = false)
+    @Column(name = "language", nullable = false, columnDefinition = "varchar")
     var language: Language = language
         protected set
 
-    @Lob
     @Column(name = "content", nullable = false)
     var content: String = content
         protected set

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/News.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/News.kt
@@ -24,7 +24,7 @@ class News(
 ) : PrimaryKeyEntity() {
 
     @Enumerated(EnumType.STRING)
-    @Column(name = "news_type", nullable = false)
+    @Column(name = "news_type", nullable = false, columnDefinition = "varchar")
     var newsType: NewsType = newsType
         protected set
 

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/News.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/News.kt
@@ -32,7 +32,7 @@ class News(
     var originId: Long = originId
         protected set
 
-    @Column(name = "originUrl", nullable = false)
+    @Column(name = "origin_url", nullable = false)
     var originUrl: String = originUrl
         protected set
 

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,6 +1,22 @@
 spring:
+  datasource:
+    url: jdbc:mysql://localhost:13306/sckorea
+    username: root
+    password: root
+    driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
     open-in-view: false
     hibernate:
       ddl-auto: validate
     show-sql: true
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+logging:
+  level:
+    org:
+      hibernate:
+        orm:
+          jdbc:
+            bind: trace

--- a/src/main/resources/db/migration/V1__init_news.sql
+++ b/src/main/resources/db/migration/V1__init_news.sql
@@ -1,0 +1,26 @@
+CREATE TABLE content
+(
+    sequence BIGINT AUTO_INCREMENT NOT NULL,
+    news_id  BINARY(16)            NOT NULL,
+    language VARCHAR(255)          NOT NULL,
+    content  TEXT                  NOT NULL,
+    title    VARCHAR(255)          NOT NULL,
+    excerpt  VARCHAR(255)          NULL,
+    CONSTRAINT pk_content PRIMARY KEY (sequence)
+);
+
+CREATE TABLE news
+(
+    id                BINARY(16)   NOT NULL,
+    news_type         VARCHAR(255) NOT NULL,
+    origin_id         BIGINT       NOT NULL,
+    origin_url        VARCHAR(255) NOT NULL,
+    published_at      DATETIME     NOT NULL,
+    support_languages VARCHAR(255) NOT NULL,
+    title             VARCHAR(255) NOT NULL,
+    excerpt           VARCHAR(255) NULL,
+    CONSTRAINT pk_news PRIMARY KEY (id)
+);
+
+ALTER TABLE content
+    ADD CONSTRAINT FK_CONTENT_ON_NEWS FOREIGN KEY (news_id) REFERENCES news (id);


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #11

## PR 세부 내용

지금까지 정의된 엔티티에 대해 DDL 파일을 추가했습니다.

`Language`, `NewsType`과 같은 Enum 타입은 `@Enumerated(EnumType.STRING)` 어노테이션을 사용하여 DB에 varchar 타입으로 저장되게 하였지만, 하이버네이트 schema validation에서 enum 타입이 아니라고 예외를 던지더군요. 😂
이전 프로젝트에선 이런 일이 없어 당황스러웠네요.
우선 `columnDefinition = "varchar"` 속성으로 해결했습니다.

또한 Content의 content 컬럼은 원래 BLOB(LONGTEXT) 이었지만, 뉴스의 길이가 64KB를 넘기지 않을 것 같아 TEXT로 타입을 설정했습니다.
나중에 번역된 뉴스의 길이를 보고 BLOB으로 변경할 수 있어야 할 것 같네요. 

또한 local 프로파일에 MySQL, Flyway, 로깅 등 설정을 추가했습니다.
local 프로파일은 개인 마다 설정을 다르게 할 필요가 있으므로 `.gitignore`에 등록하여 깃의 staging 대상에 들어가지 않도록 하는 방법도 좋아보이네요.

