### PR TITLE
fix: excerpt 컬럼 길이 255 -> 512 변경 (#26)

### DIFF
--- a/src/main/resources/db/migration/V1__init_news.sql
+++ b/src/main/resources/db/migration/V1__init_news.sql
@@ -5,7 +5,7 @@ CREATE TABLE content
     language VARCHAR(255)          NOT NULL,
     content  TEXT                  NOT NULL,
     title    VARCHAR(255)          NOT NULL,
-    excerpt  VARCHAR(255)          NULL,
+    excerpt  VARCHAR(512)          NULL,
     CONSTRAINT pk_content PRIMARY KEY (sequence)
 );
 
@@ -18,7 +18,7 @@ CREATE TABLE news
     published_at      DATETIME     NOT NULL,
     support_languages VARCHAR(255) NOT NULL,
     title             VARCHAR(255) NOT NULL,
-    excerpt           VARCHAR(255) NULL,
+    excerpt           VARCHAR(512) NULL,
     CONSTRAINT pk_news PRIMARY KEY (id)
 );
 


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #26

## PR 세부 내용

이슈 내용 그대로 `excerpt` 컬럼의 길이를 `varchar(255)` -> `varchar(512)`로 변경했습니다.
지금 생각해보면 `news` 테이블에 `excerpt` 컬럼이 과연 필요한지 생각이 드네요.
이것은 추후 와이어프레임을 만들며 얘기를 해봐야 할 것 같습니다.
