### PR TITLE
feat: Discord 기반 OAuth2 인증 구현 (#12)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -39,6 +39,7 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-jdbc")
     implementation("org.springframework.boot:spring-boot-starter-validation")
     implementation("org.springframework.boot:spring-boot-starter-web")
+    implementation("org.springframework.boot:spring-boot-starter-webflux")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.flywaydb:flyway-core")
     implementation("org.flywaydb:flyway-mysql")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,11 @@ dependencies {
 
     // Mock Web Server
     testImplementation("com.squareup.okhttp3:mockwebserver")
+
+    // JWT
+    implementation("io.jsonwebtoken:jjwt-api:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-impl:0.12.3")
+    runtimeOnly("io.jsonwebtoken:jjwt-jackson:0.12.3")
 }
 
 tasks.withType<KotlinCompile> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,9 @@ dependencies {
 
     // Jsoup
     implementation("org.jsoup:jsoup:1.17.1")
+
+    // Mock Web Server
+    testImplementation("com.squareup.okhttp3:mockwebserver")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/docs/asciidoc/auth-api.adoc
+++ b/src/docs/asciidoc/auth-api.adoc
@@ -1,0 +1,15 @@
+[[auth-api]]
+== 인증
+
+[[auth-oauth2-login]]
+=== OAuth2 로그인
+
+*요청*
+
+include::{snippets}/auth/oauth2/login/http-request.adoc[]
+include::{snippets}/auth/oauth2/login/query-parameters.adoc[]
+
+*응답*
+
+include::{snippets}/auth/oauth2/login/http-response.adoc[]
+include::{snippets}/auth/oauth2/login/response-fields.adoc[]

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -7,3 +7,5 @@
 include::news-api.adoc[]
 
 include::crawler-api.adoc[]
+
+include::auth-api.adoc[]

--- a/src/main/kotlin/kr/galaxyhub/sc/api/common/ExceptionHandler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/common/ExceptionHandler.kt
@@ -4,6 +4,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import kr.galaxyhub.sc.common.exception.GalaxyhubException
 import kr.galaxyhub.sc.common.support.LogLevel
+import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
@@ -33,6 +34,18 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
 
     private fun MissingServletRequestParameterException.missingParameters(): String {
         return this.detailMessageArguments.contentToString()
+    }
+
+    override fun handleTypeMismatch(
+        ex: TypeMismatchException,
+        headers: HttpHeaders,
+        status: HttpStatusCode,
+        request: WebRequest,
+    ): ResponseEntity<Any> {
+        return ResponseEntity(
+            ApiResponse("${ex.propertyName}에 잘못된 값이 입력 되었습니다.", "${ex.propertyName},${ex.value}"),
+            HttpStatus.BAD_REQUEST
+        )
     }
 
     @ExceptionHandler(GalaxyhubException::class)

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/auth/oauth2/OAuth2ControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/auth/oauth2/OAuth2ControllerV1.kt
@@ -1,0 +1,28 @@
+package kr.galaxyhub.sc.api.v1.auth.oauth2
+
+import kr.galaxyhub.sc.api.common.ApiResponse
+import kr.galaxyhub.sc.auth.application.OAuth2FacadeService
+import kr.galaxyhub.sc.auth.application.dto.LoginResponse
+import kr.galaxyhub.sc.member.domain.SocialType
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/auth/oauth2")
+class OAuth2ControllerV1(
+    val oAuth2FacadeService: OAuth2FacadeService,
+) {
+
+    @GetMapping("/login")
+    fun login(
+        @RequestParam code: String,
+        @RequestParam socialType: SocialType,
+    ): ResponseEntity<ApiResponse<LoginResponse>> {
+        val response = oAuth2FacadeService.login(code, socialType)
+        return ResponseEntity.ok()
+            .body(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/application/OAuth2CommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/application/OAuth2CommandService.kt
@@ -1,0 +1,29 @@
+package kr.galaxyhub.sc.auth.application
+
+import kr.galaxyhub.sc.auth.application.dto.LoginResponse
+import kr.galaxyhub.sc.auth.domain.JwtProvider
+import kr.galaxyhub.sc.member.domain.Member
+import kr.galaxyhub.sc.member.domain.MemberRepository
+import kr.galaxyhub.sc.member.domain.UserInfo
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class OAuth2CommandService(
+    private val memberRepository: MemberRepository,
+    private val jwtProvider: JwtProvider,
+) {
+
+    fun login(userInfo: UserInfo): LoginResponse {
+        val member = memberRepository.findBySocialIdAndSocialType(userInfo.socialId, userInfo.socialType)
+            ?: signup(userInfo)
+        val accessToken = jwtProvider.provide(member)
+        return LoginResponse(accessToken, member.nickname, member.profileImage)
+    }
+
+    private fun signup(userInfo: UserInfo): Member {
+        val member = userInfo.toMember()
+        return memberRepository.save(member)
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/application/OAuth2FacadeService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/application/OAuth2FacadeService.kt
@@ -1,0 +1,24 @@
+package kr.galaxyhub.sc.auth.application
+
+import kr.galaxyhub.sc.auth.application.dto.LoginResponse
+import kr.galaxyhub.sc.auth.domain.OAuth2Clients
+import kr.galaxyhub.sc.member.domain.SocialType
+import org.springframework.stereotype.Service
+
+/**
+ * 외부 API를 호출하는 서비스이기 때문에 Transcational 어노테이션을 사용하지 않습니다.
+ * OAuth2Clients에서 OAuth2 서버에 API 호출을 하기 때문에, 해당 클래스를 만들어 사용합니다. -> 트랜잭션 범위 최소화 목적
+ */
+@Service
+class OAuth2FacadeService(
+    private val oAuth2Clients: OAuth2Clients,
+    private val oAuth2CommandService: OAuth2CommandService,
+) {
+
+    fun login(code: String, socialType: SocialType): LoginResponse {
+        val client = oAuth2Clients.getClient(socialType)
+        val accessToken = client.getAccessToken(code)
+        val userInfo = client.getUserInfo(accessToken)
+        return oAuth2CommandService.login(userInfo)
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/application/dto/LoginResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/application/dto/LoginResponse.kt
@@ -1,0 +1,7 @@
+package kr.galaxyhub.sc.auth.application.dto
+
+data class LoginResponse(
+    val accessToken: String,
+    val nickname: String,
+    val imageUrl: String?,
+)

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/config/OAuth2WebClientConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/config/OAuth2WebClientConfig.kt
@@ -1,0 +1,36 @@
+package kr.galaxyhub.sc.auth.config
+
+import kr.galaxyhub.sc.auth.domain.OAuth2Client
+import kr.galaxyhub.sc.auth.domain.OAuth2Clients
+import kr.galaxyhub.sc.auth.infra.DiscordOAuth2Client
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class OAuth2WebClientConfig(
+    private val webClient: WebClient,
+) {
+
+    @Bean
+    fun discordOAuth2Client(
+        @Value("\${galaxyhub.oauth2.discord.client_id}") clientId: String,
+        @Value("\${galaxyhub.oauth2.discord.client_secret}") clientSecret: String,
+        @Value("\${galaxyhub.oauth2.discord.redirect_uri}") redirectUri: String,
+    ): OAuth2Client {
+        return DiscordOAuth2Client(
+            webClient = webClient.mutate()
+                .baseUrl("https://discord.com")
+                .build(),
+            clientId = clientId,
+            clientSecret = clientSecret,
+            redirectUri = redirectUri
+        )
+    }
+
+    @Bean
+    fun oAuth2Clients(oAuth2Clients: List<OAuth2Client>): OAuth2Clients {
+        return OAuth2Clients.from(oAuth2Clients)
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/config/OAuth2WebClientConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/config/OAuth2WebClientConfig.kt
@@ -3,9 +3,13 @@ package kr.galaxyhub.sc.auth.config
 import kr.galaxyhub.sc.auth.domain.OAuth2Client
 import kr.galaxyhub.sc.auth.domain.OAuth2Clients
 import kr.galaxyhub.sc.auth.infra.DiscordOAuth2Client
+import kr.galaxyhub.sc.auth.infra.LocalOAuth2Client
+import kr.galaxyhub.sc.member.domain.SocialType
+import kr.galaxyhub.sc.member.domain.UserInfo
 import org.springframework.beans.factory.annotation.Value
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.context.annotation.Profile
 import org.springframework.web.reactive.function.client.WebClient
 
 @Configuration
@@ -27,6 +31,15 @@ class OAuth2WebClientConfig(
             clientSecret = clientSecret,
             redirectUri = redirectUri
         )
+    }
+
+    @Bean
+    @Profile("!prod")
+    fun localOAuth2Client(): OAuth2Client {
+        val memory = mutableMapOf<String, UserInfo>()
+        memory["1"] = UserInfo(SocialType.LOCAL, "1", "seokjin8678@gmail.com", "seokjin8678", null)
+        memory["2"] = UserInfo(SocialType.LOCAL, "2", "laeng@gmail.com", "laeng", null)
+        return LocalOAuth2Client(memory)
     }
 
     @Bean

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/domain/JwtProvider.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/domain/JwtProvider.kt
@@ -1,0 +1,8 @@
+package kr.galaxyhub.sc.auth.domain
+
+import kr.galaxyhub.sc.member.domain.Member
+
+fun interface JwtProvider {
+
+    fun provide(member: Member): String
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/domain/OAuth2Client.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/domain/OAuth2Client.kt
@@ -1,0 +1,13 @@
+package kr.galaxyhub.sc.auth.domain
+
+import kr.galaxyhub.sc.member.domain.SocialType
+import kr.galaxyhub.sc.member.domain.UserInfo
+
+interface OAuth2Client {
+
+    fun getAccessToken(code: String): String
+
+    fun getUserInfo(accessToken: String): UserInfo
+
+    fun getSocialType(): SocialType
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/domain/OAuth2Clients.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/domain/OAuth2Clients.kt
@@ -1,0 +1,26 @@
+package kr.galaxyhub.sc.auth.domain
+
+import java.util.EnumMap
+import kr.galaxyhub.sc.common.exception.BadRequestException
+import kr.galaxyhub.sc.member.domain.SocialType
+
+class OAuth2Clients(
+    private val oAuth2Clients: Map<SocialType, OAuth2Client>,
+) {
+
+    fun getClient(socialType: SocialType): OAuth2Client {
+        return oAuth2Clients[socialType]
+            ?: throw BadRequestException("해당 OAuth2 서비스 제공자는 제공되지 않습니다. socialType=$socialType")
+    }
+
+    companion object {
+
+        fun from(oAuth2Clients: List<OAuth2Client>): OAuth2Clients {
+            val oAuth2ClientMap = EnumMap<SocialType, OAuth2Client>(SocialType::class.java)
+            oAuth2Clients.forEach {
+                oAuth2ClientMap[it.getSocialType()] = it
+            }
+            return OAuth2Clients(oAuth2ClientMap)
+        }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2Client.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2Client.kt
@@ -4,12 +4,15 @@ import com.fasterxml.jackson.databind.PropertyNamingStrategies
 import com.fasterxml.jackson.databind.annotation.JsonNaming
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kr.galaxyhub.sc.auth.domain.OAuth2Client
+import kr.galaxyhub.sc.common.exception.BadRequestException
 import kr.galaxyhub.sc.common.exception.InternalServerError
 import kr.galaxyhub.sc.member.domain.SocialType
 import kr.galaxyhub.sc.member.domain.UserInfo
 import org.springframework.http.HttpHeaders
+import org.springframework.http.HttpStatus
 import org.springframework.util.LinkedMultiValueMap
 import org.springframework.util.MultiValueMap
+import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
 
@@ -28,12 +31,24 @@ class DiscordOAuth2Client(
             .bodyValue(createAccessTokenBodyForm(code))
             .retrieve()
             .onStatus({ it.is4xxClientError || it.is5xxServerError }) {
-                log.warn { "getAccessToken() 호출에서 ${it.statusCode()} 예외가 발생했습니다." }
-                throw InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다.")
+                throw handleAccessTokenError(it)
             }
             .bodyToMono<DiscordAccessTokenResponse>()
             .block()!!
             .accessToken
+    }
+
+    private fun handleAccessTokenError(clientResponse: ClientResponse): Exception {
+        return when (clientResponse.statusCode()) {
+            HttpStatus.UNAUTHORIZED -> {
+                BadRequestException("잘못된 OAuth2 Authorization 코드입니다.")
+            }
+
+            else -> {
+                log.warn { "getAccessToken() 호출에서 ${clientResponse.statusCode()} 예외가 발생했습니다." }
+                InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다.")
+            }
+        }
     }
 
     private fun createAccessTokenBodyForm(code: String): MultiValueMap<String, String> {

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2Client.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2Client.kt
@@ -1,0 +1,94 @@
+package kr.galaxyhub.sc.auth.infra
+
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.annotation.JsonNaming
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kr.galaxyhub.sc.auth.domain.OAuth2Client
+import kr.galaxyhub.sc.common.exception.InternalServerError
+import kr.galaxyhub.sc.member.domain.SocialType
+import kr.galaxyhub.sc.member.domain.UserInfo
+import org.springframework.http.HttpHeaders
+import org.springframework.util.LinkedMultiValueMap
+import org.springframework.util.MultiValueMap
+import org.springframework.web.reactive.function.client.WebClient
+import org.springframework.web.reactive.function.client.bodyToMono
+
+private val log = KotlinLogging.logger {}
+
+class DiscordOAuth2Client(
+    private val webClient: WebClient,
+    private val clientId: String,
+    private val clientSecret: String,
+    private val redirectUri: String,
+) : OAuth2Client {
+
+    override fun getAccessToken(code: String): String {
+        return webClient.post()
+            .uri("/api/oauth2/token")
+            .bodyValue(createAccessTokenBodyForm(code))
+            .retrieve()
+            .onStatus({ it.is4xxClientError || it.is5xxServerError }) {
+                log.warn { "getAccessToken() 호출에서 ${it.statusCode()} 예외가 발생했습니다." }
+                throw InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다.")
+            }
+            .bodyToMono<DiscordAccessTokenResponse>()
+            .block()!!
+            .accessToken
+    }
+
+    private fun createAccessTokenBodyForm(code: String): MultiValueMap<String, String> {
+        val multiValueMap = LinkedMultiValueMap<String, String>()
+        multiValueMap.add("client_id", clientId)
+        multiValueMap.add("client_secret", clientSecret)
+        multiValueMap.add("code", code)
+        multiValueMap.add("grant_type", "authorization_code")
+        multiValueMap.add("redirect_uri", redirectUri)
+        return multiValueMap
+    }
+
+    override fun getUserInfo(accessToken: String): UserInfo {
+        return webClient.get()
+            .uri("/api/users/@me")
+            .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
+            .retrieve()
+            .onStatus({ it.is4xxClientError || it.is5xxServerError }) {
+                log.warn { "getUserInfo() 호출에서 ${it.statusCode()} 예외가 발생했습니다." }
+                throw InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다.")
+            }
+            .bodyToMono<DiscordUserInfoResponse>()
+            .block()!!
+            .toUserInfo()
+    }
+
+    override fun getSocialType(): SocialType {
+        return SocialType.DISCORD
+    }
+}
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class DiscordAccessTokenResponse(
+    val accessToken: String,
+    val tokenType: String,
+    val expiresIn: Long,
+    val refreshToken: String,
+    val scope: String,
+)
+
+@JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)
+data class DiscordUserInfoResponse(
+    val id: String,
+    val username: String,
+    val email: String?,
+    val avatar: String?,
+) {
+
+    fun toUserInfo(): UserInfo {
+        return UserInfo(
+            email = email,
+            nickname = username,
+            socialType = SocialType.DISCORD,
+            socialId = id,
+            profileImage = avatar?.let { "https://cdn.discordapp.com/avatars/${id}/${avatar}.png" }
+        )
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/infra/JwtProviderImpl.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/infra/JwtProviderImpl.kt
@@ -1,0 +1,14 @@
+package kr.galaxyhub.sc.auth.infra
+
+import kr.galaxyhub.sc.auth.domain.JwtProvider
+import kr.galaxyhub.sc.member.domain.Member
+import org.springframework.stereotype.Component
+
+@Component
+class JwtProviderImpl : JwtProvider {
+
+    override fun provide(member: Member): String {
+        // TODO 새로운 이슈로 만들어 기능 추가할 것
+        return "accessToken"
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/infra/LocalOAuth2Client.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/infra/LocalOAuth2Client.kt
@@ -1,0 +1,32 @@
+package kr.galaxyhub.sc.auth.infra
+
+import kr.galaxyhub.sc.auth.domain.OAuth2Client
+import kr.galaxyhub.sc.common.exception.BadRequestException
+import kr.galaxyhub.sc.member.domain.SocialType
+import kr.galaxyhub.sc.member.domain.UserInfo
+
+class LocalOAuth2Client(
+    private val memory: MutableMap<String, UserInfo>,
+) : OAuth2Client {
+
+    override fun getAccessToken(code: String): String {
+        return code
+    }
+
+    override fun getUserInfo(accessToken: String): UserInfo {
+        return memory[accessToken]
+            ?: throw BadRequestException("잘못된 OAuth2 Authorization 코드입니다. available=${memory.keys}")
+    }
+
+    override fun getSocialType(): SocialType {
+        return SocialType.LOCAL
+    }
+
+    fun clear() {
+        memory.clear()
+    }
+
+    fun put(accessToken: String, userInfo: UserInfo) {
+        memory[accessToken] = userInfo
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/common/config/WebClientConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/config/WebClientConfig.kt
@@ -1,0 +1,18 @@
+package kr.galaxyhub.sc.common.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.reactive.function.client.WebClient
+
+/**
+ * 공통 설정을 해놓은 WebClient를 빈으로 등록하는 클래스
+ */
+@Configuration
+class WebClientConfig {
+
+    @Bean
+    fun webClient(): WebClient {
+        return WebClient.builder()
+            .build()
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/InternalServerError.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/InternalServerError.kt
@@ -1,0 +1,11 @@
+package kr.galaxyhub.sc.common.exception
+
+import kr.galaxyhub.sc.common.support.LogLevel
+import org.springframework.http.HttpStatus
+import org.springframework.http.HttpStatusCode
+
+class InternalServerError(
+    message: String,
+    httpStatus: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR,
+    logLevel: LogLevel = LogLevel.WARN,
+) : GalaxyhubException(message, httpStatus, logLevel)

--- a/src/main/kotlin/kr/galaxyhub/sc/member/domain/Member.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/member/domain/Member.kt
@@ -1,0 +1,38 @@
+package kr.galaxyhub.sc.member.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import kr.galaxyhub.sc.common.domain.PrimaryKeyEntity
+
+@Entity
+class Member(
+    socialId: String,
+    socialType: SocialType,
+    nickname: String,
+    email: String?,
+    profileImage: String?,
+) : PrimaryKeyEntity() {
+
+    @Column(name = "social_id", nullable = false)
+    var socialId: String = socialId
+        protected set
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type", nullable = false, columnDefinition = "varchar")
+    var socialType: SocialType = socialType
+        protected set
+
+    @Column(name = "nickname", nullable = false)
+    var nickname: String = nickname
+        protected set
+
+    @Column(name = "email", nullable = true)
+    var email: String? = email
+        protected set
+
+    @Column(name = "profile_image", nullable = true)
+    var profileImage: String? = profileImage
+        protected set
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/member/domain/MemberRepository.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/member/domain/MemberRepository.kt
@@ -1,0 +1,11 @@
+package kr.galaxyhub.sc.member.domain
+
+import java.util.UUID
+import org.springframework.data.repository.Repository
+
+interface MemberRepository : Repository<Member, UUID> {
+
+    fun findBySocialIdAndSocialType(socialId: String, socialType: SocialType): Member?
+
+    fun save(member: Member): Member
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/member/domain/SocialType.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/member/domain/SocialType.kt
@@ -1,0 +1,16 @@
+package kr.galaxyhub.sc.member.domain
+
+import java.util.Locale
+
+enum class SocialType {
+    LOCAL,
+    DISCORD,
+    ;
+
+    companion object {
+
+        fun from(lowerCase: String): SocialType {
+            return SocialType.valueOf(lowerCase.uppercase(Locale.getDefault()))
+        }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/member/domain/UserInfo.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/member/domain/UserInfo.kt
@@ -1,0 +1,9 @@
+package kr.galaxyhub.sc.member.domain
+
+data class UserInfo(
+    val socialType: SocialType,
+    val socialId: String,
+    val email: String?,
+    val nickname: String,
+    val profileImage: String?,
+)

--- a/src/main/kotlin/kr/galaxyhub/sc/member/domain/UserInfo.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/member/domain/UserInfo.kt
@@ -6,4 +6,15 @@ data class UserInfo(
     val email: String?,
     val nickname: String,
     val profileImage: String?,
-)
+) {
+
+    fun toMember(): Member {
+        return Member(
+            socialId = socialId,
+            socialType = socialType,
+            nickname = nickname,
+            email = email,
+            profileImage = profileImage
+        )
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -20,3 +20,9 @@ logging:
         orm:
           jdbc:
             bind: trace
+galaxyhub:
+  oauth2:
+    discord:
+      client_id: 123123
+      client_secret: 123123
+      redirect_uri: http://localhost:8080/api/v1/auth/oauth2/login?socialType=discord

--- a/src/main/resources/db/migration/V2__add_member.sql
+++ b/src/main/resources/db/migration/V2__add_member.sql
@@ -1,0 +1,6 @@
+CREATE TABLE member
+(
+    id BINARY(16) NOT NULL,
+    CONSTRAINT pk_member PRIMARY KEY (id)
+);
+

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/auth/oauth2/OAuth2ControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/auth/oauth2/OAuth2ControllerV1Test.kt
@@ -1,0 +1,55 @@
+package kr.galaxyhub.sc.api.v1.auth.oauth2
+
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import kr.galaxyhub.sc.api.support.ENUM
+import kr.galaxyhub.sc.api.support.STRING
+import kr.galaxyhub.sc.api.support.andDocument
+import kr.galaxyhub.sc.api.support.docGet
+import kr.galaxyhub.sc.api.support.param
+import kr.galaxyhub.sc.api.support.pathMeans
+import kr.galaxyhub.sc.api.support.type
+import kr.galaxyhub.sc.auth.application.OAuth2FacadeService
+import kr.galaxyhub.sc.auth.application.dto.LoginResponse
+import kr.galaxyhub.sc.member.domain.SocialType
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(OAuth2ControllerV1::class)
+@AutoConfigureRestDocs
+class OAuth2ControllerV1Test(
+    private val mockMvc: MockMvc,
+    @MockkBean
+    private val oAuth2FacadeService: OAuth2FacadeService,
+) : DescribeSpec({
+
+    describe("POST /api/v1/auth/oauth2/login") {
+        context("유효한 요청이 전달되면") {
+            it("200 응답과 로그인 정보가 반환된다.") {
+                val response = LoginResponse("abc123abc123", "seokjin8678", "https://sc.galaxyhub.kr/image.png")
+                every { oAuth2FacadeService.login(any(), any()) } returns response
+
+                mockMvc.docGet("/api/v1/auth/oauth2/login") {
+                    contentType = MediaType.APPLICATION_JSON
+                    param("code" to "1123123")
+                    param("socialType" to "DISCORD")
+                }.andExpect {
+                    status { isOk() }
+                }.andDocument("auth/oauth2/login") {
+                    queryParameters(
+                        "code" pathMeans "Authorization 코드",
+                        "socialType" pathMeans "OAuth2 소셜 타입" formattedAs ENUM(SocialType.entries.filter { it != SocialType.LOCAL }),
+                    )
+                    responseBody(
+                        "data.accessToken" type STRING means "Bearer JWT Access Token",
+                        "data.nickname" type STRING means "사용자의 닉네임",
+                        "data.imageUrl" type STRING means "사용자의 프로필 사진 링크" isOptional true,
+                    )
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/kr/galaxyhub/sc/auth/application/OAuth2CommandServiceTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/application/OAuth2CommandServiceTest.kt
@@ -1,0 +1,56 @@
+package kr.galaxyhub.sc.auth.application
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import kr.galaxyhub.sc.auth.domain.JwtProvider
+import kr.galaxyhub.sc.member.domain.MemoryMemberRepository
+import kr.galaxyhub.sc.member.domain.SocialType
+import kr.galaxyhub.sc.member.domain.UserInfo
+
+class OAuth2CommandServiceTest(
+    private val memoryMemberRepository: MemoryMemberRepository = MemoryMemberRepository(),
+    private val fakeJwtProvider: JwtProvider = JwtProvider { "accessToken" },
+    private val oAuth2CommandService: OAuth2CommandService = OAuth2CommandService(
+        memoryMemberRepository,
+        fakeJwtProvider
+    ),
+) : DescribeSpec({
+
+    beforeContainer {
+        memoryMemberRepository.clear()
+    }
+
+    describe("login") {
+        val socialId = "1"
+        val socialType = SocialType.LOCAL
+        val userInfo = UserInfo(socialType, socialId, null, "seokjin8678", null)
+
+        context("socialId와 socialType에 해당하는 회원이 없으면") {
+            val expect = withContext(Dispatchers.IO) {
+                oAuth2CommandService.login(userInfo)
+            }
+
+            it("정상적으로 UserResponse가 반환된다.") {
+                expect.nickname shouldBe userInfo.nickname
+            }
+
+            it("새로운 회원이 가입된다.") {
+                memoryMemberRepository.findBySocialIdAndSocialType(socialId, socialType)
+            }
+        }
+
+        context("socialId와 socialType에 해당하는 회원이 있으면") {
+            memoryMemberRepository.save(userInfo.toMember())
+
+            val expect = withContext(Dispatchers.IO) {
+                oAuth2CommandService.login(userInfo)
+            }
+
+            it("정상적으로 UserResponse가 반환된다.") {
+                expect.nickname shouldBe userInfo.nickname
+            }
+        }
+    }
+})

--- a/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
@@ -1,0 +1,111 @@
+package kr.galaxyhub.sc.auth.infra
+
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import kr.galaxyhub.sc.common.exception.InternalServerError
+import kr.galaxyhub.sc.common.support.enqueue
+import okhttp3.mockwebserver.MockWebServer
+import org.springframework.web.reactive.function.client.WebClient
+
+class DiscordOAuth2ClientTest : DescribeSpec({
+
+    val objectMapper = jacksonObjectMapper()
+    val mockWebServer = MockWebServer()
+    val discordOAuth2Client = DiscordOAuth2Client(
+        webClient = WebClient.builder()
+            .baseUrl("${mockWebServer.url("/")}")
+            .build(),
+        clientId = "client_id",
+        clientSecret = "client_secret",
+        redirectUri = "https://sc.galaxyhub.kr"
+    )
+
+    describe("getAccessToken") {
+        context("외부 서버가 200 응답을 반환하면") {
+            val response = DiscordAccessTokenResponse(
+                accessToken = "123123",
+                tokenType = "Bearer",
+                expiresIn = 3000,
+                refreshToken = "321321",
+                scope = "email"
+            )
+            mockWebServer.enqueue {
+                statusCode(200)
+                body(objectMapper.writeValueAsString(response))
+            }
+
+            val actual = response.accessToken
+            val expect = discordOAuth2Client.getAccessToken("code")
+
+            it("AccessToken이 정상적으로 반환된다.") {
+                expect shouldBe actual
+            }
+        }
+
+        context("외부 서버가 400 응답을 반환하면") {
+            mockWebServer.enqueue { statusCode(400) }
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getAccessToken("code") }
+                ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
+            }
+        }
+
+        context("외부 서버가 500 응답을 반환하면") {
+            mockWebServer.enqueue { statusCode(500) }
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getAccessToken("code") }
+                ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
+            }
+        }
+    }
+
+    describe("getUserInfo") {
+        context("외부 서버가 200 응답을 반환하면") {
+            val response = DiscordUserInfoResponse(
+                id = "12345",
+                username = "seokjin8678",
+                email = "seokjin8678@email.com",
+                avatar = "avatar",
+            )
+            mockWebServer.enqueue {
+                statusCode(200)
+                body(objectMapper.writeValueAsString(response))
+            }
+
+            val actual = response.toUserInfo()
+            val expect = discordOAuth2Client.getUserInfo("accessToken")
+
+            it("UserInfo가 정상적으로 반환된다.") {
+                expect shouldBe actual
+            }
+
+            it("profileImage는 https://cdn.discordapp.com/avatars/{id}/{avatar}.png 형식이다.") {
+                expect.profileImage shouldBe "https://cdn.discordapp.com/avatars/${response.id}/${response.avatar}.png"
+            }
+        }
+
+        context("외부 서버가 400 응답을 반환하면") {
+            mockWebServer.enqueue { statusCode(400) }
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getUserInfo("accessToken") }
+                ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
+            }
+        }
+
+        context("외부 서버가 500 응답을 반환하면") {
+            mockWebServer.enqueue { statusCode(500) }
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getUserInfo("accessToken") }
+                ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
+            }
+        }
+    }
+})
+

--- a/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
@@ -5,6 +5,7 @@ import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import kr.galaxyhub.sc.common.exception.BadRequestException
 import kr.galaxyhub.sc.common.exception.InternalServerError
 import kr.galaxyhub.sc.common.support.enqueue
 import okhttp3.mockwebserver.MockWebServer
@@ -51,6 +52,15 @@ class DiscordOAuth2ClientTest : DescribeSpec({
             it("InternalServerError 예외를 던진다.") {
                 val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getAccessToken("code") }
                 ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
+            }
+        }
+
+        context("외부 서버가 401 응답을 반환하면") {
+            mockWebServer.enqueue { statusCode(401) }
+
+            it("BadRequestException 예외를 던진다.") {
+                val ex = shouldThrow<BadRequestException> { discordOAuth2Client.getAccessToken("wrong code") }
+                ex shouldHaveMessage "잘못된 OAuth2 Authorization 코드입니다."
             }
         }
 

--- a/src/test/kotlin/kr/galaxyhub/sc/auth/infra/LocalOAuth2ClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/infra/LocalOAuth2ClientTest.kt
@@ -1,0 +1,50 @@
+package kr.galaxyhub.sc.auth.infra
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.throwable.shouldHaveMessage
+import kr.galaxyhub.sc.common.exception.BadRequestException
+import kr.galaxyhub.sc.member.domain.SocialType
+import kr.galaxyhub.sc.member.domain.UserInfo
+
+class LocalOAuth2ClientTest(
+    private val localOAuth2Client: LocalOAuth2Client = LocalOAuth2Client(mutableMapOf()),
+) : DescribeSpec({
+
+    beforeContainer {
+        localOAuth2Client.clear()
+    }
+
+    describe("getAccessToken") {
+        context("AccessToken을 요청하면") {
+            val expect = localOAuth2Client.getAccessToken("code")
+
+            it("파라미터로 넣은 code가 그대로 반환된다.") {
+                expect shouldBe "code"
+            }
+        }
+    }
+
+    describe("getUserInfo") {
+        val accessToken = "1"
+
+        context("accessToken에 해당하는 사용자가 있으면") {
+            val actual = UserInfo(SocialType.LOCAL, "1", null, "seokjin8678", null)
+            localOAuth2Client.put(accessToken, actual)
+
+            val expect = localOAuth2Client.getUserInfo(accessToken)
+
+            it("UserInfo가 반환된다.") {
+                expect shouldBe actual
+            }
+        }
+
+        context("accessToken에 해당하는 사용자가 없으면") {
+            it("BadRequestException 예외를 던진다.") {
+                val ex = shouldThrow<BadRequestException> { localOAuth2Client.getUserInfo(accessToken) }
+                ex shouldHaveMessage "잘못된 OAuth2 Authorization 코드입니다. available=[]"
+            }
+        }
+    }
+})

--- a/src/test/kotlin/kr/galaxyhub/sc/common/support/MockWebServerDsl.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/common/support/MockWebServerDsl.kt
@@ -1,0 +1,41 @@
+package kr.galaxyhub.sc.common.support
+
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+
+class MockWebServerDsl {
+
+    private var statusCode: Int? = null
+    private var body: String? = null
+    private var mediaType: String? = null
+
+    fun statusCode(statusCode: Int) {
+        this.statusCode = statusCode
+    }
+
+    fun body(body: String) {
+        this.body = body
+    }
+
+    fun mediaType(mediaType: MediaType) {
+        this.mediaType = mediaType.toString()
+    }
+
+    internal fun perform(mockWebServer: MockWebServer) {
+        val response = MockResponse()
+        statusCode?.also { response.setResponseCode(it) }
+        body?.also { response.setBody(it) }
+        if (mediaType != null) {
+            response.addHeader(HttpHeaders.CONTENT_TYPE, mediaType!!)
+        } else {
+            response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+        }
+        mockWebServer.enqueue(response)
+    }
+}
+
+fun MockWebServer.enqueue(dsl: MockWebServerDsl.() -> Unit = {}) {
+    MockWebServerDsl().apply(dsl).perform(this)
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/member/domain/MemoryMemberRepository.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/member/domain/MemoryMemberRepository.kt
@@ -1,0 +1,21 @@
+package kr.galaxyhub.sc.member.domain
+
+import java.util.UUID
+
+class MemoryMemberRepository(
+    private val memory: MutableMap<UUID, Member> = mutableMapOf(),
+) : MemberRepository {
+
+    override fun findBySocialIdAndSocialType(socialId: String, socialType: SocialType): Member? {
+        return memory.values.firstOrNull { it.socialId == socialId && it.socialType == socialType }
+    }
+
+    override fun save(member: Member): Member {
+        memory[member.id] = member
+        return member
+    }
+
+    fun clear() {
+        memory.clear()
+    }
+}

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -18,3 +18,9 @@ logging:
         orm:
           jdbc:
             bind: trace
+galaxyhub:
+  oauth2:
+    discord:
+      client_id: discord_id
+      client_secret: discord_client_secret
+      redirect_uri: http://localhost:8080/api/v1/auth/oauth2/code?provider=discord

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,11 +1,12 @@
 
-==== Response Fields
-|===
-|필드명|타입|설명
+====Response Fields
+    |===
+    |필드명|타입|설명|null여부
 
 {{#fields}}
-|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
-|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
-|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+    |{{#tableCellContent}}{{description}}{{/tableCellContent}}
+    |{{#tableCellContent}}{{#optional}}true{{/optional}}{{^optional}}{{/optional}}{{/tableCellContent}}
 {{/fields}}
-|===
+    |===


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #12

## PR 세부 내용

Discord 기반의 OAuth2 인증 기능을 구현했습니다.
자체 JWT 토큰을 반환하는 기능은 TODO로 남겨두었습니다. (한 번에 전부 구현하려면 변경 내역이 너무 많아져서 그렇습니다..!)

외부 API를 호출하는 로직은 Spring WebFlux를 사용했습니다.
이전 프로젝트에서는 RestTemplate를 사용했는데, RestTemplate의 지원이 이제 종료되어 WebFlux를 사용하라고 하더라구요.
WebFlux의 특징이 논블럭킹 비동기를 제공한다는 특징이 있는데, 제대로 사용하려면 학습 곡선이 조금 있어 그냥 `block()`를 사용하여 동기로 처리했습니다. (애초에 비동기로 처리할 수 없는 것이, 사용자는 토큰을 바로 얻어야해서.. 😂)

WebFlux로 비동기로 처리할 껀덕지는 웹 크롤링을 수행할 때인데, Jsoup로 HTML을 크롤링 하는것 또한 WebFlux를 사용해 볼 수 있을 것 같네요. 

개발, 테스트 환경에서 실제 OAuth2를 사용할 필요는 없으니, `LocalOAuth2Client`를 사용하면 될 것 같습니다.

자세한 내용은 코드에 리뷰로 남기겠습니다.