### PR TITLE
chore: Crawler 인터페이스 패키지 이동 (#37)

### DIFF
--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/application/Crawler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/application/Crawler.kt
@@ -1,4 +1,6 @@
-package kr.galaxyhub.sc.news.application
+package kr.galaxyhub.sc.crawler.application
+
+import kr.galaxyhub.sc.news.application.NewsCreateCommand
 
 interface Crawler {
 

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/application/CrawlerCommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/application/CrawlerCommandService.kt
@@ -1,7 +1,6 @@
 package kr.galaxyhub.sc.crawler.application
 
 import java.util.UUID
-import kr.galaxyhub.sc.crawler.infra.Crawlers
 import kr.galaxyhub.sc.news.application.NewsCommandService
 import org.springframework.stereotype.Service
 

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/application/Crawlers.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/application/Crawlers.kt
@@ -1,7 +1,6 @@
-package kr.galaxyhub.sc.crawler.infra
+package kr.galaxyhub.sc.crawler.application
 
 import kr.galaxyhub.sc.common.exception.BadRequestException
-import kr.galaxyhub.sc.news.application.Crawler
 import kr.galaxyhub.sc.news.application.NewsCreateCommand
 
 class Crawlers(

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/config/CrawlerConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/config/CrawlerConfig.kt
@@ -1,9 +1,9 @@
 package kr.galaxyhub.sc.crawler.config
 
 import com.fasterxml.jackson.databind.ObjectMapper
+import kr.galaxyhub.sc.crawler.application.Crawlers
 import kr.galaxyhub.sc.crawler.domain.DocumentProvider
 import kr.galaxyhub.sc.crawler.domain.HtmlParser
-import kr.galaxyhub.sc.crawler.infra.Crawlers
 import kr.galaxyhub.sc.crawler.infra.EngineeringCrawler
 import kr.galaxyhub.sc.crawler.infra.parser.MarkdownHtmlParser
 import kr.galaxyhub.sc.crawler.infra.parser.PlainHtmlParser

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/infra/EngineeringCrawler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/infra/EngineeringCrawler.kt
@@ -5,10 +5,10 @@ import com.fasterxml.jackson.module.kotlin.readValue
 import java.time.ZoneId
 import java.time.ZonedDateTime
 import kr.galaxyhub.sc.common.exception.BadRequestException
+import kr.galaxyhub.sc.crawler.application.Crawler
 import kr.galaxyhub.sc.crawler.domain.DocumentProvider
 import kr.galaxyhub.sc.crawler.domain.HtmlParser
 import kr.galaxyhub.sc.crawler.domain.Introduction
-import kr.galaxyhub.sc.news.application.Crawler
 import kr.galaxyhub.sc.news.application.NewsCreateCommand
 import kr.galaxyhub.sc.news.domain.Language
 import kr.galaxyhub.sc.news.domain.NewsType

--- a/src/test/kotlin/kr/galaxyhub/sc/crawler/application/CrawlersTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/crawler/application/CrawlersTest.kt
@@ -1,9 +1,10 @@
-package kr.galaxyhub.sc.crawler.infra
+package kr.galaxyhub.sc.crawler.application
 
 import io.kotest.assertions.throwables.shouldNotThrow
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.DescribeSpec
 import kr.galaxyhub.sc.common.exception.BadRequestException
+import kr.galaxyhub.sc.crawler.infra.FakeCrawler
 
 class CrawlersTest : DescribeSpec({
     var crawlers: Crawlers

--- a/src/test/kotlin/kr/galaxyhub/sc/crawler/infra/FakeCrawler.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/crawler/infra/FakeCrawler.kt
@@ -3,7 +3,7 @@ package kr.galaxyhub.sc.crawler.infra
 import java.time.LocalDateTime
 import java.time.ZoneId
 import java.time.ZonedDateTime
-import kr.galaxyhub.sc.news.application.Crawler
+import kr.galaxyhub.sc.crawler.application.Crawler
 import kr.galaxyhub.sc.news.application.NewsCreateCommand
 import kr.galaxyhub.sc.news.domain.Language
 import kr.galaxyhub.sc.news.domain.NewsType


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #37

## PR 세부 내용

이슈 내용 그대로, `Crawler` 인터페이스의 패키지 위치를 news에서 crawler로 이동하였습니다.