### PR TITLE
chore: dev 브랜치 배포 자동화 Github Actions 추가 (#52)

### DIFF
--- a/.github/workflows/cd-back-dev.yml
+++ b/.github/workflows/cd-back-dev.yml
@@ -1,0 +1,53 @@
+name: cd-back-dev
+
+on:
+  push:
+    branches:
+      - dev
+    paths: 'src/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: repository checkout
+        uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: ${{ secrets.SUBMODULE_TOKEN }}
+
+      - name: install java 17
+        uses: actions/setup-java@v3
+        with:
+          java-version: 17
+          distribution: 'zulu'
+
+      - name: assign grant gradlew
+        run: chmod +x gradlew
+
+      - name: build with gradle
+        run: ./gradlew build
+
+      - name: deploy use scp
+        uses: appleboy/scp-action@master
+        with:
+          host: ${{vars.SCKR_DEV_IP}}
+          username: ${{secrets.SCKR_DEV_USERNAME}}
+          key: ${{secrets.SCKR_DEV_SSH_KEY}}
+          source: "./build/libs/*.jar"
+          target: ${{ vars.SCKR_DEV_JAR_DIR }}
+          strip_components: 3
+
+      - name: run application use ssh
+        uses: appleboy/ssh-action@master
+        with:
+          host: ${{vars.SCKR_DEV_IP}}
+          username: ${{secrets.SCKR_DEV_USERNAME}}
+          key: ${{secrets.SCKR_DEV_SSH_KEY}}
+          script_stop: true
+          script: ${{ vars.SCKR_DEV_DEPLOY_COMMAND }}


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #52

## PR 세부 내용

이슈 내용 그대로, dev 브랜치에 merge가 되면 배포를 자동화 하는 Githun Actions를 추가했습니다.
