### PR TITLE
feat: 번역 도메인 API, 엔티티 설계 (#54)

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -9,3 +9,5 @@ include::news-api.adoc[]
 include::crawler-api.adoc[]
 
 include::auth-api.adoc[]
+
+include::translation-api.adoc[]

--- a/src/docs/asciidoc/translation-api.adoc
+++ b/src/docs/asciidoc/translation-api.adoc
@@ -1,0 +1,25 @@
+[[translation-api]]
+== 번역
+
+[[translation-translate]]
+=== 뉴스 번역 요청
+
+*요청*
+include::{snippets}/translation/translate/http-request.adoc[]
+include::{snippets}/translation/translate/path-parameters.adoc[]
+include::{snippets}/translation/translate/request-fields.adoc[]
+
+*응답*
+include::{snippets}/translation/translate/http-response.adoc[]
+include::{snippets}/translation/translate/response-fields.adoc[]
+
+[[translation-find-by-id]]
+=== 번역 진행 상황 단건 조회
+
+*요청*
+include::{snippets}/translation/find-by-id/http-request.adoc[]
+include::{snippets}/translation/find-by-id/path-parameters.adoc[]
+
+*응답*
+include::{snippets}/translation/find-by-id/http-response.adoc[]
+include::{snippets}/translation/find-by-id/response-fields.adoc[]

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/translation/TranslationControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/translation/TranslationControllerV1.kt
@@ -1,0 +1,45 @@
+package kr.galaxyhub.sc.api.v1.translation
+
+import java.util.UUID
+import kr.galaxyhub.sc.api.common.ApiResponse
+import kr.galaxyhub.sc.api.v1.translation.dto.TranslationRequest
+import kr.galaxyhub.sc.common.support.toUri
+import kr.galaxyhub.sc.translation.application.TranslationCommandService
+import kr.galaxyhub.sc.translation.application.TranslationQueryService
+import kr.galaxyhub.sc.translation.application.dto.TranslationCommand
+import kr.galaxyhub.sc.translation.application.dto.TranslationResponse
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/translation")
+class TranslationControllerV1(
+    private val translationCommandService: TranslationCommandService,
+    private val translationQueryService: TranslationQueryService,
+) {
+
+    @PostMapping("/{newsId}")
+    fun translate(
+        @PathVariable newsId: UUID,
+        @RequestBody request: TranslationRequest,
+    ): ResponseEntity<ApiResponse<UUID>> {
+        val command = TranslationCommand(newsId, request.destinationLanguage)
+        val translateProgressionId = translationCommandService.translate(command)
+        return ResponseEntity.created("/api/v1/translation/${translateProgressionId}".toUri())
+            .body(ApiResponse.success(translateProgressionId))
+    }
+
+    @GetMapping("/{translateProgressionId}")
+    fun findById(
+        @PathVariable translateProgressionId: UUID,
+    ): ResponseEntity<ApiResponse<TranslationResponse>> {
+        val response = translationQueryService.findById(translateProgressionId)
+        return ResponseEntity.ok()
+            .body(ApiResponse.success(response))
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/translation/dto/TranslationRequest.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/translation/dto/TranslationRequest.kt
@@ -1,0 +1,7 @@
+package kr.galaxyhub.sc.api.v1.translation.dto
+
+import kr.galaxyhub.sc.news.domain.Language
+
+data class TranslationRequest(
+    val destinationLanguage: Language
+)

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationCommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationCommandService.kt
@@ -1,0 +1,23 @@
+package kr.galaxyhub.sc.translation.application
+
+import java.util.UUID
+import kr.galaxyhub.sc.translation.application.dto.TranslationCommand
+import kr.galaxyhub.sc.translation.domain.TranslateProgression
+import kr.galaxyhub.sc.translation.domain.TranslationProgressionRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional
+class TranslationCommandService(
+    private val translationProgressionRepository: TranslationProgressionRepository
+) {
+
+    fun translate(command: TranslationCommand): UUID {
+        val newsId = command.newsId
+        val destinationLanguage = command.destinationLanguage
+        val translateProgression = TranslateProgression(newsId, destinationLanguage)
+        translationProgressionRepository.save(translateProgression)
+        return translateProgression.id
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationQueryService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationQueryService.kt
@@ -1,0 +1,20 @@
+package kr.galaxyhub.sc.translation.application
+
+import java.util.UUID
+import kr.galaxyhub.sc.translation.application.dto.TranslationResponse
+import kr.galaxyhub.sc.translation.domain.TranslationProgressionRepository
+import kr.galaxyhub.sc.translation.domain.getOrThrow
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class TranslationQueryService(
+    private val translationProgressionRepository: TranslationProgressionRepository,
+) {
+
+    fun findById(translateProgressionId: UUID): TranslationResponse {
+        return translationProgressionRepository.getOrThrow(translateProgressionId)
+            .let { TranslationResponse.from(it) }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/application/dto/TranslationCommand.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/application/dto/TranslationCommand.kt
@@ -1,0 +1,9 @@
+package kr.galaxyhub.sc.translation.application.dto
+
+import java.util.UUID
+import kr.galaxyhub.sc.news.domain.Language
+
+data class TranslationCommand(
+    val newsId: UUID,
+    val destinationLanguage: Language
+)

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/application/dto/TranslationResponse.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/application/dto/TranslationResponse.kt
@@ -1,0 +1,25 @@
+package kr.galaxyhub.sc.translation.application.dto
+
+import java.util.UUID
+import kr.galaxyhub.sc.translation.domain.TranslateProgression
+import kr.galaxyhub.sc.translation.domain.TranslationStatus
+
+data class TranslationResponse(
+    val translateProgressionId: UUID,
+    val targetNewsId: UUID,
+    val translationStatus: TranslationStatus,
+    val message: String? = null,
+) {
+
+    companion object {
+
+        fun from(translationProgression: TranslateProgression): TranslationResponse {
+            return TranslationResponse(
+                translateProgressionId = translationProgression.id,
+                targetNewsId = translationProgression.newsId,
+                translationStatus = translationProgression.translationStatus,
+                message = translationProgression.message
+            )
+        }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/domain/TranslateProgression.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/domain/TranslateProgression.kt
@@ -1,0 +1,45 @@
+package kr.galaxyhub.sc.translation.domain
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import java.util.UUID
+import kr.galaxyhub.sc.common.domain.PrimaryKeyEntity
+import kr.galaxyhub.sc.news.domain.Language
+
+@Entity
+@Table(
+    uniqueConstraints = [
+        UniqueConstraint(
+            name = "UNIQUE_NEWS_ID_AND_DESTINATION_LANGUAGE",
+            columnNames = [
+                "news_id",
+                "destination_language"
+            ]
+        )
+    ]
+)
+class TranslateProgression(
+    newsId: UUID,
+    destinationLanguage: Language,
+) : PrimaryKeyEntity() {
+
+    @Column(name = "news_id", nullable = false, columnDefinition = "uuid")
+    val newsId: UUID = newsId
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "destination_language", nullable = false, columnDefinition = "varchar")
+    val destinationLanguage: Language = destinationLanguage
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "translation_status", nullable = false, columnDefinition = "varchar")
+    var translationStatus: TranslationStatus = TranslationStatus.PROGRESS
+        protected set
+
+    @Column(name = "message")
+    var message: String? = null
+        protected set
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/domain/TranslationProgressionRepository.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/domain/TranslationProgressionRepository.kt
@@ -1,0 +1,15 @@
+package kr.galaxyhub.sc.translation.domain
+
+import java.util.UUID
+import kr.galaxyhub.sc.common.exception.NotFoundException
+import org.springframework.data.repository.Repository
+
+fun TranslationProgressionRepository.getOrThrow(translateProgressionId: UUID) = findById(translateProgressionId)
+    ?: throw NotFoundException("식별자에 대한 번역 진행 상황을 찾을 수 없습니다. id=$translateProgressionId")
+
+interface TranslationProgressionRepository : Repository<TranslateProgression, UUID> {
+
+    fun save(translateProgression: TranslateProgression): TranslateProgression
+
+    fun findById(translateProgressionId: UUID): TranslateProgression?
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/domain/TranslationStatus.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/domain/TranslationStatus.kt
@@ -1,0 +1,7 @@
+package kr.galaxyhub.sc.translation.domain
+
+enum class TranslationStatus {
+    PROGRESS,
+    COMPLETE,
+    ERROR,
+}

--- a/src/main/resources/db/migration/V3__add_translate_progression.sql
+++ b/src/main/resources/db/migration/V3__add_translate_progression.sql
@@ -1,0 +1,12 @@
+CREATE TABLE translate_progression
+(
+    id                   BINARY(36)   NOT NULL,
+    news_id              BINARY(36)   NOT NULL,
+    destination_language VARCHAR(255) NOT NULL,
+    translation_status   VARCHAR(255) NOT NULL,
+    message              VARCHAR(255) NULL,
+    CONSTRAINT pk_translate_progression PRIMARY KEY (id)
+);
+
+ALTER TABLE translate_progression
+    ADD CONSTRAINT UNIQUE_NEWS_ID_AND_DESTINATION_LANGUAGE UNIQUE (news_id, destination_language);

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/translation/TranslationControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/translation/TranslationControllerV1Test.kt
@@ -1,0 +1,95 @@
+package kr.galaxyhub.sc.api.v1.translation
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import io.kotest.core.spec.style.DescribeSpec
+import io.mockk.every
+import java.util.UUID
+import kr.galaxyhub.sc.api.support.ENUM
+import kr.galaxyhub.sc.api.support.STRING
+import kr.galaxyhub.sc.api.support.andDocument
+import kr.galaxyhub.sc.api.support.docGet
+import kr.galaxyhub.sc.api.support.docPost
+import kr.galaxyhub.sc.api.support.pathMeans
+import kr.galaxyhub.sc.api.support.type
+import kr.galaxyhub.sc.api.v1.translation.dto.TranslationRequest
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.translation.application.TranslationCommandService
+import kr.galaxyhub.sc.translation.application.TranslationQueryService
+import kr.galaxyhub.sc.translation.application.dto.TranslationResponse
+import kr.galaxyhub.sc.translation.domain.TranslationStatus
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.MockMvc
+
+@WebMvcTest(TranslationControllerV1::class)
+@AutoConfigureRestDocs
+class TranslationControllerV1Test(
+    private val mockMvc: MockMvc,
+    private val objectMapper: ObjectMapper,
+    @MockkBean
+    private val translationCommandService: TranslationCommandService,
+    @MockkBean
+    private val translationQueryService: TranslationQueryService,
+) : DescribeSpec({
+
+    describe("POST /api/v1/translation/{newsId}") {
+        context("유효한 요청이 전달되면") {
+            val request = TranslationRequest(Language.KOREAN)
+            val newsId = UUID.randomUUID()
+            every { translationCommandService.translate(any()) } returns UUID.randomUUID()
+
+            it("201 응답과 번역 진행 상황의 식별자가 반환된다.") {
+                mockMvc.docPost("/api/v1/translation/{newsId}", newsId) {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(request)
+                }.andExpect {
+                    status { isCreated() }
+                }.andDocument("translation/translate") {
+                    pathParameters(
+                        "newsId" pathMeans "번역할 뉴스의 식별자"
+                    )
+                    requestBody(
+                        "destinationLanguage" type ENUM(Language::class) means "번역 도착 언어"
+                    )
+                    responseBody(
+                        "data" type STRING means "번역 진행 상황의 식별자"
+                    )
+                }
+            }
+        }
+    }
+
+    describe("GET /api/v1/translation/{translateProgressionId}") {
+        context("유효한 요청이 전달되면") {
+            val translateProgressionId = UUID.randomUUID()
+            val response = translationResponse(translateProgressionId)
+            every { translationQueryService.findById(any()) } returns response
+
+            it("200 응답과 번역 진행 상황의 정보가 조회된다.") {
+                mockMvc.docGet("/api/v1/translation/{translateProgressionId}", translateProgressionId) {
+                    contentType = MediaType.APPLICATION_JSON
+                }.andExpect {
+                    status { isOk() }
+                }.andDocument("translation/find-by-id") {
+                    pathParameters(
+                        "translateProgressionId" pathMeans "번역 진행 상황의 식별자"
+                    )
+                    responseBody(
+                        "data.translateProgressionId" type STRING means "번역 진행 상황의 식별자",
+                        "data.targetNewsId" type STRING means "번역할 뉴스의 식별자",
+                        "data.translationStatus" type ENUM(TranslationStatus::class) means "번역 상태",
+                        "data.message" type STRING means "번역 진행 상황의 추가적 메시지" isOptional true
+                    )
+                }
+            }
+        }
+    }
+})
+
+private fun translationResponse(translateProgressionId: UUID) = TranslationResponse(
+    translateProgressionId = translateProgressionId,
+    targetNewsId = UUID.randomUUID(),
+    translationStatus = TranslationStatus.PROGRESS,
+)

--- a/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,12 +1,13 @@
 
 ==== Response Fields
 |===
-|필드명|타입|설명|null여부
+|필드명|타입|설명|null여부|형식
 
 {{#fields}}
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 |{{#tableCellContent}}{{#optional}}true{{/optional}}{{^optional}}{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}{{format}}{{/format}}{{^format}}{{/format}}{{/tableCellContent}}
 {{/fields}}
 |===


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #54

## PR 세부 내용

번역 도메인의 API와 엔티티를 우선 설계했습니다.

### 엔티티

번역 요청을 비동기로 처리하기 위해 엔티티의 이름을 `TranslateProgression`로 하였습니다.
`TranslateProgression`을 한글로 풀어서 표현한다면 `번역 진행 상태`가 어울릴 것 같은데, 어떤 이름으로 부르는게 좋을까요..?

또한 뉴스가 중복으로 번역되는 것을 막기 위해 `newsId`, `destinationLanguage`를 복합 유니크 인덱스로 설정하였습니다.

`message` 컬럼은 번역에 실패했을 때 어떤 사유로 번역에 실패했는지 알려주기 위한 컬럼이라고 보시면 됩니다. (타임아웃, 연결 실패, 비용 초과 등)

`translationStatus` 컬럼으로 번역의 상태를 나타내었습니다. (`진행중`, `완료`, `에러`)
에러 보다는 실패(failure)로 할 걸 그랬나 싶네요. 😂

번역 재요청을 하려면 번역의 상태가 실패일때만 진행할 수 있게 비즈니스 로직을 작성할 수 있을 것 같습니다!

### API

`/api/v1/translation/{newsId}` URI로 번역할 언어(destinationLanguage)를 Body에 담아 POST 요청을 보내면 번역 진행 상태의 식별자를 반환합니다. 이때 응답은 200 OK가 아닌, 201 CREATE로 하였습니다. (새로운 자원이 생성되므로)

`/api/v1/translation/{translateProgressionId}`에 GET 요청을 보내면, 번역 진행 상태의 정보를 반환합니다.

---

결론은 번역 요청을 보내는 기능을 구현하기 전에 도메인 용어부터 확실하게 정하고 가면 좋을 것 같습니다! 
