### PR TITLE
feat: WebClient 예외 핸들링 리팩터링, Timeout 예외 핸들링 추가 (#60)

### DIFF
--- a/src/main/kotlin/kr/galaxyhub/sc/auth/config/OAuth2WebClientConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/config/OAuth2WebClientConfig.kt
@@ -1,5 +1,6 @@
 package kr.galaxyhub.sc.auth.config
 
+import java.time.Duration
 import kr.galaxyhub.sc.auth.domain.OAuth2Client
 import kr.galaxyhub.sc.auth.domain.OAuth2Clients
 import kr.galaxyhub.sc.auth.infra.DiscordOAuth2Client
@@ -29,7 +30,8 @@ class OAuth2WebClientConfig(
                 .build(),
             clientId = clientId,
             clientSecret = clientSecret,
-            redirectUri = redirectUri
+            redirectUri = redirectUri,
+            timeoutDuration = Duration.ofSeconds(5)
         )
     }
 

--- a/src/main/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2Client.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2Client.kt
@@ -6,6 +6,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import kr.galaxyhub.sc.auth.domain.OAuth2Client
 import kr.galaxyhub.sc.common.exception.BadRequestException
 import kr.galaxyhub.sc.common.exception.InternalServerError
+import kr.galaxyhub.sc.common.support.handleConnectError
 import kr.galaxyhub.sc.member.domain.SocialType
 import kr.galaxyhub.sc.member.domain.UserInfo
 import org.springframework.http.HttpHeaders
@@ -15,6 +16,7 @@ import org.springframework.util.MultiValueMap
 import org.springframework.web.reactive.function.client.ClientResponse
 import org.springframework.web.reactive.function.client.WebClient
 import org.springframework.web.reactive.function.client.bodyToMono
+import reactor.core.publisher.Mono
 
 private val log = KotlinLogging.logger {}
 
@@ -30,25 +32,11 @@ class DiscordOAuth2Client(
             .uri("/api/oauth2/token")
             .bodyValue(createAccessTokenBodyForm(code))
             .retrieve()
-            .onStatus({ it.is4xxClientError || it.is5xxServerError }) {
-                throw handleAccessTokenError(it)
-            }
+            .onStatus({ it.isError }) { handleAccessTokenError(it) }
             .bodyToMono<DiscordAccessTokenResponse>()
+            .handleConnectError("Discord OAuth2 서버와 연결 중 문제가 발생했습니다.")
             .block()!!
             .accessToken
-    }
-
-    private fun handleAccessTokenError(clientResponse: ClientResponse): Exception {
-        return when (clientResponse.statusCode()) {
-            HttpStatus.UNAUTHORIZED -> {
-                BadRequestException("잘못된 OAuth2 Authorization 코드입니다.")
-            }
-
-            else -> {
-                log.warn { "getAccessToken() 호출에서 ${clientResponse.statusCode()} 예외가 발생했습니다." }
-                InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다.")
-            }
-        }
     }
 
     private fun createAccessTokenBodyForm(code: String): MultiValueMap<String, String> {
@@ -61,16 +49,30 @@ class DiscordOAuth2Client(
         return multiValueMap
     }
 
+    private fun <T> handleAccessTokenError(clientResponse: ClientResponse): Mono<T> {
+        return when (clientResponse.statusCode()) {
+            HttpStatus.UNAUTHORIZED -> {
+                Mono.error(BadRequestException("잘못된 OAuth2 Authorization 코드입니다."))
+            }
+
+            else -> {
+                log.error { "getAccessToken() 호출에서 ${clientResponse.statusCode()} 예외가 발생했습니다." }
+                Mono.error(InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다."))
+            }
+        }
+    }
+
     override fun getUserInfo(accessToken: String): UserInfo {
         return webClient.get()
             .uri("/api/users/@me")
             .header(HttpHeaders.AUTHORIZATION, "Bearer $accessToken")
             .retrieve()
-            .onStatus({ it.is4xxClientError || it.is5xxServerError }) {
-                log.warn { "getUserInfo() 호출에서 ${it.statusCode()} 예외가 발생했습니다." }
-                throw InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다.")
+            .onStatus({ it.isError }) {
+                log.error { "getUserInfo() 호출에서 ${it.statusCode()} 예외가 발생했습니다." }
+                Mono.error(InternalServerError("Discord OAuth2 서버에 문제가 발생했습니다."))
             }
             .bodyToMono<DiscordUserInfoResponse>()
+            .handleConnectError("Discord OAuth2 서버와 연결 중 문제가 발생했습니다.")
             .block()!!
             .toUserInfo()
     }

--- a/src/main/kotlin/kr/galaxyhub/sc/common/support/WebClientErrorHandler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/support/WebClientErrorHandler.kt
@@ -1,0 +1,17 @@
+package kr.galaxyhub.sc.common.support
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kr.galaxyhub.sc.common.exception.GalaxyhubException
+import kr.galaxyhub.sc.common.exception.InternalServerError
+import reactor.core.publisher.Mono
+
+private val log = KotlinLogging.logger {}
+
+fun <T> Mono<T>.handleConnectError(
+    exMessage: String = "외부 서버와 연결 중 문제가 발생했습니다.",
+): Mono<T> {
+    return onErrorResume({ it !is GalaxyhubException }) {
+        log.error(it) { exMessage }
+        Mono.error(InternalServerError(exMessage))
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationCommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationCommandService.kt
@@ -36,7 +36,7 @@ class TranslationCommandService(
         val translatorClient = translatorClients.getClient(translatorProvider)
         translatorClient.requestTranslate(content, targetLanguage)
             .doOnError {
-                log.warn { "뉴스 번역 요청이 실패하였습니다. newsId=${newsId}, translateProgressionId=${translateProgression.id}" }
+                log.info { "뉴스 번역 요청이 실패하였습니다. newsId=${newsId}, translateProgressionId=${translateProgression.id} cause=${it.message}" }
                 eventPublisher.publishEvent(TranslatorFailureEvent(translateProgression.id, it.message))
             }
             .subscribe {

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/config/TranslatorClientConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/config/TranslatorClientConfig.kt
@@ -1,5 +1,6 @@
 package kr.galaxyhub.sc.translation.config
 
+import java.time.Duration
 import kr.galaxyhub.sc.translation.domain.TranslatorClient
 import kr.galaxyhub.sc.translation.domain.TranslatorClients
 import kr.galaxyhub.sc.translation.infra.DeepLTranslatorClient
@@ -23,7 +24,7 @@ class TranslatorClientConfig(
             webClient.mutate()
                 .baseUrl("https://api.deepl.com")
                 .defaultHeader(HttpHeaders.AUTHORIZATION, "DeepL-Auth-Key $deepLApiKey")
-                .build()
+                .build(), Duration.ofSeconds(5)
         )
     }
 

--- a/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
@@ -2,6 +2,7 @@ package kr.galaxyhub.sc.auth.infra
 
 import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
@@ -12,6 +13,8 @@ import okhttp3.mockwebserver.MockWebServer
 import org.springframework.web.reactive.function.client.WebClient
 
 class DiscordOAuth2ClientTest : DescribeSpec({
+
+    isolationMode = IsolationMode.InstancePerLeaf
 
     val objectMapper = jacksonObjectMapper()
     val mockWebServer = MockWebServer()
@@ -72,6 +75,15 @@ class DiscordOAuth2ClientTest : DescribeSpec({
                 ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
             }
         }
+
+        context("외부 서버에 연결할 수 없으면") {
+            mockWebServer.shutdown()
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getAccessToken("code") }
+                ex shouldHaveMessage "외부 서버에 연결할 수 없습니다."
+            }
+        }
     }
 
     describe("getUserInfo") {
@@ -114,6 +126,15 @@ class DiscordOAuth2ClientTest : DescribeSpec({
             it("InternalServerError 예외를 던진다.") {
                 val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getUserInfo("accessToken") }
                 ex shouldHaveMessage "Discord OAuth2 서버에 문제가 발생했습니다."
+            }
+        }
+
+        context("외부 서버에 연결할 수 없으면") {
+            mockWebServer.shutdown()
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getUserInfo("accessToken") }
+                ex shouldHaveMessage "외부 서버에 연결할 수 없습니다."
             }
         }
     }

--- a/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
@@ -1,11 +1,12 @@
 package kr.galaxyhub.sc.auth.infra
 
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.IsolationMode
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.throwable.shouldHaveMessage
+import java.time.Duration
+import java.util.concurrent.TimeUnit
 import kr.galaxyhub.sc.common.exception.BadRequestException
 import kr.galaxyhub.sc.common.exception.InternalServerError
 import kr.galaxyhub.sc.common.support.enqueue
@@ -16,7 +17,6 @@ class DiscordOAuth2ClientTest : DescribeSpec({
 
     isolationMode = IsolationMode.InstancePerLeaf
 
-    val objectMapper = jacksonObjectMapper()
     val mockWebServer = MockWebServer()
     val discordOAuth2Client = DiscordOAuth2Client(
         webClient = WebClient.builder()
@@ -24,21 +24,23 @@ class DiscordOAuth2ClientTest : DescribeSpec({
             .build(),
         clientId = "client_id",
         clientSecret = "client_secret",
-        redirectUri = "https://sc.galaxyhub.kr"
+        redirectUri = "https://sc.galaxyhub.kr",
+        timeoutDuration = Duration.ofSeconds(10)
     )
 
     describe("getAccessToken") {
+        val response = DiscordAccessTokenResponse(
+            accessToken = "123123",
+            tokenType = "Bearer",
+            expiresIn = 3000,
+            refreshToken = "321321",
+            scope = "email"
+        )
+
         context("외부 서버가 200 응답을 반환하면") {
-            val response = DiscordAccessTokenResponse(
-                accessToken = "123123",
-                tokenType = "Bearer",
-                expiresIn = 3000,
-                refreshToken = "321321",
-                scope = "email"
-            )
             mockWebServer.enqueue {
                 statusCode(200)
-                body(objectMapper.writeValueAsString(response))
+                body(response)
             }
 
             val actual = response.accessToken
@@ -81,22 +83,45 @@ class DiscordOAuth2ClientTest : DescribeSpec({
 
             it("InternalServerError 예외를 던진다.") {
                 val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getAccessToken("code") }
-                ex shouldHaveMessage "외부 서버에 연결할 수 없습니다."
+                ex shouldHaveMessage "Discord OAuth2 서버와 연결 중 문제가 발생했습니다."
+            }
+        }
+
+        context("외부 서버에 지연이 발생하면") {
+            val delayClient = DiscordOAuth2Client(
+                webClient = WebClient.builder()
+                    .baseUrl("${mockWebServer.url("/")}")
+                    .build(),
+                clientId = "client_id",
+                clientSecret = "client_secret",
+                redirectUri = "https://sc.galaxyhub.kr",
+                timeoutDuration = Duration.ofMillis(100)
+            )
+            mockWebServer.enqueue {
+                statusCode(200)
+                body(response)
+                delay(10, TimeUnit.SECONDS)
+            }
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { delayClient.getAccessToken("code") }
+                ex shouldHaveMessage "Discord OAuth2 서버의 응답 시간이 초과되었습니다."
             }
         }
     }
 
     describe("getUserInfo") {
+        val response = DiscordUserInfoResponse(
+            id = "12345",
+            username = "seokjin8678",
+            email = "seokjin8678@email.com",
+            avatar = "avatar",
+        )
+
         context("외부 서버가 200 응답을 반환하면") {
-            val response = DiscordUserInfoResponse(
-                id = "12345",
-                username = "seokjin8678",
-                email = "seokjin8678@email.com",
-                avatar = "avatar",
-            )
             mockWebServer.enqueue {
                 statusCode(200)
-                body(objectMapper.writeValueAsString(response))
+                body(response)
             }
 
             val actual = response.toUserInfo()
@@ -134,7 +159,29 @@ class DiscordOAuth2ClientTest : DescribeSpec({
 
             it("InternalServerError 예외를 던진다.") {
                 val ex = shouldThrow<InternalServerError> { discordOAuth2Client.getUserInfo("accessToken") }
-                ex shouldHaveMessage "외부 서버에 연결할 수 없습니다."
+                ex shouldHaveMessage "Discord OAuth2 서버와 연결 중 문제가 발생했습니다."
+            }
+        }
+
+        context("외부 서버에 지연이 발생하면") {
+            val delayClient = DiscordOAuth2Client(
+                webClient = WebClient.builder()
+                    .baseUrl("${mockWebServer.url("/")}")
+                    .build(),
+                clientId = "client_id",
+                clientSecret = "client_secret",
+                redirectUri = "https://sc.galaxyhub.kr",
+                timeoutDuration = Duration.ofMillis(100)
+            )
+            mockWebServer.enqueue {
+                statusCode(200)
+                body(response)
+                delay(10, TimeUnit.SECONDS)
+            }
+
+            it("InternalServerError 예외를 던진다.") {
+                val ex = shouldThrow<InternalServerError> { delayClient.getUserInfo("accessToken") }
+                ex shouldHaveMessage "Discord OAuth2 서버의 응답 시간이 초과되었습니다."
             }
         }
     }

--- a/src/test/kotlin/kr/galaxyhub/sc/common/support/MockWebServerDsl.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/common/support/MockWebServerDsl.kt
@@ -1,5 +1,7 @@
 package kr.galaxyhub.sc.common.support
 
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import java.util.concurrent.TimeUnit
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.springframework.http.HttpHeaders
@@ -10,29 +12,41 @@ class MockWebServerDsl {
     private var statusCode: Int? = null
     private var body: String? = null
     private var mediaType: String? = null
+    private var delay: Long? = null
+    private var timeUnit: TimeUnit? = null
 
     fun statusCode(statusCode: Int) {
         this.statusCode = statusCode
     }
 
-    fun body(body: String) {
-        this.body = body
+    fun body(body: Any) {
+        this.body = objectMapper.writeValueAsString(body)
     }
 
     fun mediaType(mediaType: MediaType) {
         this.mediaType = mediaType.toString()
     }
 
+    fun delay(delay: Long, timeUnit: TimeUnit) {
+        this.delay = delay
+        this.timeUnit = timeUnit
+    }
+
     internal fun perform(mockWebServer: MockWebServer) {
         val response = MockResponse()
         statusCode?.also { response.setResponseCode(it) }
         body?.also { response.setBody(it) }
+        delay?.also { response.setBodyDelay(it, timeUnit!!) }
         if (mediaType != null) {
             response.addHeader(HttpHeaders.CONTENT_TYPE, mediaType!!)
         } else {
             response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
         }
         mockWebServer.enqueue(response)
+    }
+
+    companion object {
+        val objectMapper = jacksonObjectMapper()
     }
 }
 


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #60

## PR 세부 내용

이슈 내용대로 타임아웃 예외 핸들링 기능을 추가했습니다.
지금은 5초로 설정을 해뒀고, 나중에 로그를 확인하여 시간을 조절할 필요가 있을 것 같습니다.
또한, WebClient에 발생하는 중복된 코드(ex) handleConnectError())를 코틀린 확장 함수를 사용하여 제거하였습니다.