### PR TITLE
feat: ExceptionHandler 로깅 디버그일 때 출력, 각 컴포넌트에서 로깅하도록 변경 (#62)

### DIFF
--- a/src/main/kotlin/kr/galaxyhub/sc/api/common/ExceptionHandler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/common/ExceptionHandler.kt
@@ -3,7 +3,6 @@ package kr.galaxyhub.sc.api.common
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import kr.galaxyhub.sc.common.exception.GalaxyhubException
-import kr.galaxyhub.sc.common.support.LogLevel
 import org.springframework.beans.TypeMismatchException
 import org.springframework.http.HttpHeaders
 import org.springframework.http.HttpStatus
@@ -53,12 +52,7 @@ class ExceptionHandler : ResponseEntityExceptionHandler() {
         e: GalaxyhubException,
         request: HttpServletRequest,
     ): ResponseEntity<ApiResponse<Unit>> {
-        when (e.logLevel) {
-            LogLevel.ERROR -> log.error(e) { "[🔴ERROR] - (${request.method} ${request.requestURI})" }
-            LogLevel.WARN -> log.warn(e) { "[🟠WARN] - (${request.method} ${request.requestURI})" }
-            LogLevel.INFO -> log.info(e) { "[🔵INFO] - (${request.method} ${request.requestURI})" }
-            LogLevel.DEBUG -> log.debug(e) { "[🟢DEBUG] - (${request.method} ${request.requestURI})" }
-        }
+        log.debug(e) { "[🟢DEBUG] - (${request.method} ${request.requestURI})" }
         return ResponseEntity(ApiResponse.error(e.message!!), e.httpStatus)
     }
 

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/BadRequestException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/BadRequestException.kt
@@ -1,11 +1,9 @@
 package kr.galaxyhub.sc.common.exception
 
-import kr.galaxyhub.sc.common.support.LogLevel
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 
 class BadRequestException(
     message: String,
     httpStatus: HttpStatusCode = HttpStatus.BAD_REQUEST,
-    logLevel: LogLevel = LogLevel.INFO,
-) : GalaxyhubException(message, httpStatus, logLevel)
+) : GalaxyhubException(message, httpStatus)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/GalaxyhubException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/GalaxyhubException.kt
@@ -1,10 +1,8 @@
 package kr.galaxyhub.sc.common.exception
 
-import kr.galaxyhub.sc.common.support.LogLevel
 import org.springframework.http.HttpStatusCode
 
 sealed class GalaxyhubException(
     message: String,
     val httpStatus: HttpStatusCode,
-    val logLevel: LogLevel,
 ) : RuntimeException(message)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/InternalServerError.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/InternalServerError.kt
@@ -1,11 +1,9 @@
 package kr.galaxyhub.sc.common.exception
 
-import kr.galaxyhub.sc.common.support.LogLevel
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 
 class InternalServerError(
     message: String,
     httpStatus: HttpStatusCode = HttpStatus.INTERNAL_SERVER_ERROR,
-    logLevel: LogLevel = LogLevel.WARN,
-) : GalaxyhubException(message, httpStatus, logLevel)
+) : GalaxyhubException(message, httpStatus)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/NotFoundException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/NotFoundException.kt
@@ -1,11 +1,9 @@
 package kr.galaxyhub.sc.common.exception
 
-import kr.galaxyhub.sc.common.support.LogLevel
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 
 class NotFoundException(
     message: String,
     httpStatus: HttpStatusCode = HttpStatus.NOT_FOUND,
-    logLevel: LogLevel = LogLevel.DEBUG,
-) : GalaxyhubException(message, httpStatus, logLevel)
+) : GalaxyhubException(message, httpStatus)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/exception/UnauthorizedException.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/exception/UnauthorizedException.kt
@@ -1,11 +1,9 @@
 package kr.galaxyhub.sc.common.exception
 
-import kr.galaxyhub.sc.common.support.LogLevel
 import org.springframework.http.HttpStatus
 import org.springframework.http.HttpStatusCode
 
 class UnauthorizedException(
     message: String,
     httpStatus: HttpStatusCode = HttpStatus.UNAUTHORIZED,
-    logLevel: LogLevel = LogLevel.INFO,
-) : GalaxyhubException(message, httpStatus, logLevel)
+) : GalaxyhubException(message, httpStatus)

--- a/src/main/kotlin/kr/galaxyhub/sc/common/support/LogLevel.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/common/support/LogLevel.kt
@@ -1,9 +1,0 @@
-package kr.galaxyhub.sc.common.support
-
-enum class LogLevel {
-    ERROR,
-    WARN,
-    INFO,
-    DEBUG,
-    ;
-}

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/application/CrawlerLogAop.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/application/CrawlerLogAop.kt
@@ -1,0 +1,19 @@
+package kr.galaxyhub.sc.crawler.application
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.aspectj.lang.JoinPoint
+import org.aspectj.lang.annotation.AfterThrowing
+import org.aspectj.lang.annotation.Aspect
+import org.springframework.stereotype.Component
+
+private val log = KotlinLogging.logger {}
+
+@Component
+@Aspect
+class CrawlerLogAop {
+
+    @AfterThrowing(pointcut = "this(Crawler) && execution(* crawling(String))", throwing = "ex")
+    fun loggingException(joinPoint: JoinPoint, ex: Exception) {
+        log.warn { "크롤링 중 예외가 발생했습니다. message: ${ex.message} class: ${joinPoint.target}, url: ${joinPoint.args[0]}" }
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/config/CrawlerConfig.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/config/CrawlerConfig.kt
@@ -35,13 +35,18 @@ class CrawlerConfig(
     fun crawlers(): Crawlers {
         return Crawlers(
             listOf(
-                EngineeringCrawler(
-                    objectMapper = objectMapper,
-                    documentProvider = documentProvider(),
-                    contentParser = markdownHtmlParser(),
-                    introductionParser = plainHtmlParser(),
-                )
+                engineeringCrawler(),
             )
+        )
+    }
+
+    @Bean
+    fun engineeringCrawler(): EngineeringCrawler {
+        return EngineeringCrawler(
+            objectMapper = objectMapper,
+            documentProvider = documentProvider(),
+            contentParser = markdownHtmlParser(),
+            introductionParser = plainHtmlParser(),
         )
     }
 }

--- a/src/main/kotlin/kr/galaxyhub/sc/crawler/infra/EngineeringCrawler.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/crawler/infra/EngineeringCrawler.kt
@@ -24,7 +24,7 @@ import org.jsoup.nodes.Element
  *
  * 글의 내용은 g-narrative-group 태그안의 g-article 태그의 body 속성으로 나타납니다.
  */
-class EngineeringCrawler(
+open class EngineeringCrawler(
     private val objectMapper: ObjectMapper,
     private val documentProvider: DocumentProvider,
     private val contentParser: HtmlParser,


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #62

## PR 세부 내용

이슈 내용 그대로, `ExceptionHandler`에서 `GalaxyhubException`에 대한 로깅을 debug 레벨에서만 하도록 변경했습니다.

이렇게 변경되면 `Crawler` 에서 발생하는 예외가 로깅이 되지 않으므로 따로 로그 처리를 해줘야 했습니다.
하지만 Crawler는 추가될 구현체들이 많기 때문에 중복된 로그 코드가 발생할게 분명합니다.

따라서 AOP를 사용하여 Crawler 인터페이스를 구현한 클래스에 예외가 발생하면 로그를 남기도록 하였습니다.