### PR TITLE
feat: 뉴스 컨텐츠 수정 기능 추가 (#64)

### DIFF
--- a/src/docs/asciidoc/news-api.adoc
+++ b/src/docs/asciidoc/news-api.adoc
@@ -27,3 +27,12 @@ include::{snippets}/news/find-detail/query-parameters.adoc[]
 *응답*
 include::{snippets}/news/find-detail/http-response.adoc[]
 include::{snippets}/news/find-detail/response-fields.adoc[]
+
+[[news-content-update]]
+=== 뉴스 컨텐츠 수정
+*요청*
+include::{snippets}/news/update-content/http-request.adoc[]
+include::{snippets}/news/update-content/path-parameters.adoc[]
+include::{snippets}/news/update-content/request-fields.adoc[]
+*응답*
+include::{snippets}/news/update-content/http-response.adoc[]

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1.kt
@@ -32,12 +32,12 @@ class NewsControllerV1(
             .body(ApiResponse.success(response))
     }
 
-    @GetMapping("/{id}")
+    @GetMapping("/{newsId}")
     fun findDetailById(
-        @PathVariable id: UUID,
+        @PathVariable newsId: UUID,
         @RequestParam language: Language,
     ): ResponseEntity<ApiResponse<NewsDetailResponse>> {
-        val response = newsQueryService.getDetailByIdAndLanguage(id, language)
+        val response = newsQueryService.getDetailByIdAndLanguage(newsId, language)
         return ResponseEntity.ok()
             .body(ApiResponse.success(response))
     }
@@ -46,8 +46,8 @@ class NewsControllerV1(
     fun create(
         @RequestBody request: NewsCreateRequest,
     ): ResponseEntity<ApiResponse<UUID>> {
-        val id = newsCommandService.create(request.toCommand())
-        return ResponseEntity.created("/api/v1/news/${id}".toUri())
-            .body(ApiResponse.success(id))
+        val newsId = newsCommandService.create(request.toCommand())
+        return ResponseEntity.created("/api/v1/news/${newsId}".toUri())
+            .body(ApiResponse.success(newsId))
     }
 }

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1.kt
@@ -3,6 +3,7 @@ package kr.galaxyhub.sc.api.v1.news
 import java.util.UUID
 import kr.galaxyhub.sc.api.common.ApiResponse
 import kr.galaxyhub.sc.api.v1.news.dto.NewsCreateRequest
+import kr.galaxyhub.sc.api.v1.news.dto.NewsUpdateRequest
 import kr.galaxyhub.sc.common.support.toUri
 import kr.galaxyhub.sc.news.application.NewsCommandService
 import kr.galaxyhub.sc.news.application.NewsQueryService
@@ -49,5 +50,15 @@ class NewsControllerV1(
         val newsId = newsCommandService.create(request.toCommand())
         return ResponseEntity.created("/api/v1/news/${newsId}".toUri())
             .body(ApiResponse.success(newsId))
+    }
+
+    @PostMapping("/{newsId}/content")
+    fun updateContent(
+        @PathVariable newsId: UUID,
+        @RequestBody request: NewsUpdateRequest,
+    ): ResponseEntity<ApiResponse<Unit>> {
+        newsCommandService.updateContent(newsId, request.toCommand())
+        return ResponseEntity.ok()
+            .body(ApiResponse.success(Unit))
     }
 }

--- a/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/dto/NewsUpdateRequest.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/api/v1/news/dto/NewsUpdateRequest.kt
@@ -1,0 +1,23 @@
+package kr.galaxyhub.sc.api.v1.news.dto
+
+import kr.galaxyhub.sc.news.application.NewsUpdateCommand
+import kr.galaxyhub.sc.news.domain.Language
+import kr.galaxyhub.sc.news.domain.NewsInformation
+
+data class NewsUpdateRequest(
+    val language: Language,
+    val title: String?,
+    val excerpt: String?,
+    val content: String?,
+) {
+
+    fun toCommand(): NewsUpdateCommand {
+        return NewsUpdateCommand(
+            language = language,
+            newsInformation = title?.let {
+                NewsInformation(title, excerpt)
+            },
+            content = content
+        )
+    }
+}

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsCommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsCommandService.kt
@@ -8,6 +8,7 @@ import kr.galaxyhub.sc.news.domain.News
 import kr.galaxyhub.sc.news.domain.NewsInformation
 import kr.galaxyhub.sc.news.domain.NewsRepository
 import kr.galaxyhub.sc.news.domain.NewsType
+import kr.galaxyhub.sc.news.domain.getFetchByIdAndLanguage
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -33,6 +34,18 @@ class NewsCommandService(
             excerpt = command.excerpt
         ),
     )
+
+    fun updateContent(newsId: UUID, command: NewsUpdateCommand) {
+        val (language, newsInformation, content) = command
+        val news = newsRepository.getFetchByIdAndLanguage(newsId, language)
+        val contentByLanguage = news.getContentByLanguage(language)
+        newsInformation?.also {
+            contentByLanguage.updateNewsInformation(it)
+        }
+        content?.also {
+            contentByLanguage.updateContent(it)
+        }
+    }
 }
 
 data class NewsCreateCommand(
@@ -53,3 +66,9 @@ data class NewsCreateCommand(
         originUrl = originUrl
     )
 }
+
+data class NewsUpdateCommand(
+    val language: Language,
+    val newsInformation: NewsInformation?,
+    val content: String?,
+)

--- a/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsQueryService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/application/NewsQueryService.kt
@@ -5,7 +5,7 @@ import kr.galaxyhub.sc.news.application.dto.NewsDetailResponse
 import kr.galaxyhub.sc.news.application.dto.NewsResponse
 import kr.galaxyhub.sc.news.domain.Language
 import kr.galaxyhub.sc.news.domain.NewsRepository
-import kr.galaxyhub.sc.news.domain.getByDetailByIdAndLanguage
+import kr.galaxyhub.sc.news.domain.getFetchByIdAndLanguage
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -21,7 +21,7 @@ class NewsQueryService(
     }
 
     fun getDetailByIdAndLanguage(id: UUID, language: Language): NewsDetailResponse {
-        return newsRepository.getByDetailByIdAndLanguage(id, language)
+        return newsRepository.getFetchByIdAndLanguage(id, language)
             .let {
                 val content = it.getContentByLanguage(language)
                 NewsDetailResponse.of(it, content)

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/Content.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/Content.kt
@@ -39,4 +39,12 @@ class Content(
     @Column(name = "content", nullable = false)
     var content: String = content
         protected set
+
+    fun updateNewsInformation(newsInformation: NewsInformation) {
+        this.newsInformation = newsInformation
+    }
+
+    fun updateContent(content: String) {
+        this.content = content
+    }
 }

--- a/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsRepository.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/news/domain/NewsRepository.kt
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.Query
 import org.springframework.data.repository.Repository
 import org.springframework.data.repository.query.Param
 
-fun NewsRepository.getByDetailByIdAndLanguage(id: UUID, language: Language) = findFetchByIdAndLanguage(id, language)
+fun NewsRepository.getFetchByIdAndLanguage(id: UUID, language: Language) = findFetchByIdAndLanguage(id, language)
     ?: throw NotFoundException("식별자와 언어에 대한 뉴스를 찾을 수 없습니다. id=${id}, language=${language}")
 
 fun NewsRepository.getOrThrow(id: UUID) = findById(id)

--- a/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationCommandService.kt
+++ b/src/main/kotlin/kr/galaxyhub/sc/translation/application/TranslationCommandService.kt
@@ -5,7 +5,7 @@ import java.util.UUID
 import kr.galaxyhub.sc.common.support.validate
 import kr.galaxyhub.sc.news.application.dto.NewsAppendContentEvent
 import kr.galaxyhub.sc.news.domain.NewsRepository
-import kr.galaxyhub.sc.news.domain.getByDetailByIdAndLanguage
+import kr.galaxyhub.sc.news.domain.getFetchByIdAndLanguage
 import kr.galaxyhub.sc.translation.application.dto.TranslationCommand
 import kr.galaxyhub.sc.translation.application.dto.TranslatorFailureEvent
 import kr.galaxyhub.sc.translation.domain.TranslateProgression
@@ -28,7 +28,7 @@ class TranslationCommandService(
 
     fun translate(command: TranslationCommand): UUID {
         val (newsId, sourceLanguage, targetLanguage, translatorProvider) = command
-        val news = newsRepository.getByDetailByIdAndLanguage(newsId, sourceLanguage)
+        val news = newsRepository.getFetchByIdAndLanguage(newsId, sourceLanguage)
         validate(news.isSupportLanguage(targetLanguage)) { "이미 뉴스에 번역된 컨텐츠가 존재합니다. targetLanguage=$targetLanguage" }
         val content = news.getContentByLanguage(sourceLanguage)
         val translateProgression = TranslateProgression(newsId, sourceLanguage, targetLanguage, translatorProvider)


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #64 

## PR 세부 내용

뉴스의 컨텐츠를 수정하는 기능을 추가했습니다.

뉴스의 `title`, `excerpt`를 수정하지는 않고, 언어에 대한 컨텐츠를 수정합니다.

추후 뉴스의 `title`, `excerpt`을 수정할 기능이 생길 수 있어 API 경로는 `/api/v1/news/{newsId}/content`로 하였습니다.

나중에 인가 기능을 추가하여, 기능 명세에 나와있는 것 처럼 `한국어 편집자 역할을 가진자는 한국어 뉴스만 수정가능` 하도록 기능을 추가해야 할 것 같네요!