### PR TITLE
feat: MockWebServer 일부 테스트 코드 개선 (#69)

### DIFF
--- a/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/auth/infra/DiscordOAuth2ClientTest.kt
@@ -28,6 +28,10 @@ class DiscordOAuth2ClientTest : DescribeSpec({
         timeoutDuration = Duration.ofSeconds(10)
     )
 
+    afterEach {
+        mockWebServer.shutdown()
+    }
+
     describe("getAccessToken") {
         val response = DiscordAccessTokenResponse(
             accessToken = "123123",
@@ -100,7 +104,7 @@ class DiscordOAuth2ClientTest : DescribeSpec({
             mockWebServer.enqueue {
                 statusCode(200)
                 body(response)
-                delay(10, TimeUnit.SECONDS)
+                delay(200, TimeUnit.MILLISECONDS)
             }
 
             it("InternalServerError 예외를 던진다.") {
@@ -176,7 +180,7 @@ class DiscordOAuth2ClientTest : DescribeSpec({
             mockWebServer.enqueue {
                 statusCode(200)
                 body(response)
-                delay(10, TimeUnit.SECONDS)
+                delay(200, TimeUnit.MILLISECONDS)
             }
 
             it("InternalServerError 예외를 던진다.") {

--- a/src/test/kotlin/kr/galaxyhub/sc/common/support/MockWebServerDsl.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/common/support/MockWebServerDsl.kt
@@ -11,7 +11,7 @@ class MockWebServerDsl {
 
     private var statusCode: Int? = null
     private var body: String? = null
-    private var mediaType: String? = null
+    private var mediaType: MediaType? = null
     private var delay: Long? = null
     private var timeUnit: TimeUnit? = null
 
@@ -24,7 +24,7 @@ class MockWebServerDsl {
     }
 
     fun mediaType(mediaType: MediaType) {
-        this.mediaType = mediaType.toString()
+        this.mediaType = mediaType
     }
 
     fun delay(delay: Long, timeUnit: TimeUnit) {
@@ -35,12 +35,13 @@ class MockWebServerDsl {
     internal fun perform(mockWebServer: MockWebServer) {
         val response = MockResponse()
         statusCode?.also { response.setResponseCode(it) }
-        body?.also { response.setBody(it) }
+        body?.also {
+            response.setBody(it)
+            response.setHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+        }
         delay?.also { response.setBodyDelay(it, timeUnit!!) }
-        if (mediaType != null) {
-            response.addHeader(HttpHeaders.CONTENT_TYPE, mediaType!!)
-        } else {
-            response.addHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON)
+        mediaType?.also {
+            response.setHeader(HttpHeaders.CONTENT_TYPE, it)
         }
         mockWebServer.enqueue(response)
     }

--- a/src/test/kotlin/kr/galaxyhub/sc/translation/infra/DeepLTranslatorClientTest.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/translation/infra/DeepLTranslatorClientTest.kt
@@ -29,6 +29,10 @@ class DeepLTranslatorClientTest : DescribeSpec({
         timeoutDuration = Duration.ofSeconds(10)
     )
 
+    afterEach {
+        mockWebServer.shutdown()
+    }
+
     describe("requestTranslate") {
         val response = DeepLResponse(
             listOf(
@@ -124,7 +128,7 @@ class DeepLTranslatorClientTest : DescribeSpec({
             mockWebServer.enqueue {
                 statusCode(200)
                 body(response)
-                delay(1, TimeUnit.SECONDS)
+                delay(200, TimeUnit.MILLISECONDS)
             }
 
             val expect = delayClient.requestTranslate(ContentFixture.create(), Language.KOREAN)


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #69 

## PR 세부 내용

이슈 내용 그대로 MockWebServer를 사용하는 테스트 코드를 개선했습니다.

명시적으로 `afterEach`를 사용하여 테스트가 종료될 때 `shutdown()` 메서드를 호출하게 하여 자원을 반환하게 하였습니다.

또한 DSL의 일부 로직을 가독성있게 개선했습니다.