### PR TITLE
feat: Controller 테스트에서 Application Context 재활용하도록 변경 (#78)

### DIFF
--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/auth/oauth2/OAuth2ControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/auth/oauth2/OAuth2ControllerV1Test.kt
@@ -1,7 +1,5 @@
 package kr.galaxyhub.sc.api.v1.auth.oauth2
 
-import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
 import kr.galaxyhub.sc.api.support.ENUM
 import kr.galaxyhub.sc.api.support.STRING
@@ -12,19 +10,15 @@ import kr.galaxyhub.sc.api.support.pathMeans
 import kr.galaxyhub.sc.api.support.type
 import kr.galaxyhub.sc.auth.application.OAuth2FacadeService
 import kr.galaxyhub.sc.auth.application.dto.LoginResponse
+import kr.galaxyhub.sc.config.spec.ControllerTestSpec
 import kr.galaxyhub.sc.member.domain.SocialType
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
-@WebMvcTest(OAuth2ControllerV1::class)
-@AutoConfigureRestDocs
 class OAuth2ControllerV1Test(
     private val mockMvc: MockMvc,
-    @MockkBean
     private val oAuth2FacadeService: OAuth2FacadeService,
-) : DescribeSpec({
+) : ControllerTestSpec({
 
     describe("POST /api/v1/auth/oauth2/login") {
         context("유효한 요청이 전달되면") {

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/crawler/CrawlerControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/crawler/CrawlerControllerV1Test.kt
@@ -1,8 +1,6 @@
 package kr.galaxyhub.sc.api.v1.crawler
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
 import java.util.UUID
 import kr.galaxyhub.sc.api.support.STRING
@@ -10,20 +8,16 @@ import kr.galaxyhub.sc.api.support.andDocument
 import kr.galaxyhub.sc.api.support.docPost
 import kr.galaxyhub.sc.api.support.type
 import kr.galaxyhub.sc.api.v1.crawler.dto.NewsCrawlingRequest
+import kr.galaxyhub.sc.config.spec.ControllerTestSpec
 import kr.galaxyhub.sc.crawler.application.CrawlerCommandService
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
-@WebMvcTest(CrawlerControllerV1::class)
-@AutoConfigureRestDocs
 class CrawlerControllerV1Test(
     private val mockMvc: MockMvc,
     private val objectMapper: ObjectMapper,
-    @MockkBean
     private val crawlerCommandService: CrawlerCommandService,
-) : DescribeSpec({
+) : ControllerTestSpec({
 
     describe("POST /api/v1/crawler") {
         context("유요한 요청이 전달되면") {

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/news/NewsControllerV1Test.kt
@@ -1,8 +1,6 @@
 package kr.galaxyhub.sc.api.v1.news
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
 import io.mockk.justRun
 import java.time.LocalDateTime
@@ -23,27 +21,22 @@ import kr.galaxyhub.sc.api.support.pathMeans
 import kr.galaxyhub.sc.api.support.type
 import kr.galaxyhub.sc.api.v1.news.dto.NewsCreateRequest
 import kr.galaxyhub.sc.api.v1.news.dto.NewsUpdateRequest
+import kr.galaxyhub.sc.config.spec.ControllerTestSpec
 import kr.galaxyhub.sc.news.application.NewsCommandService
 import kr.galaxyhub.sc.news.application.NewsQueryService
 import kr.galaxyhub.sc.news.application.dto.NewsDetailResponse
 import kr.galaxyhub.sc.news.application.dto.NewsResponse
 import kr.galaxyhub.sc.news.domain.Language
 import kr.galaxyhub.sc.news.domain.NewsType
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
-@WebMvcTest(NewsControllerV1::class)
-@AutoConfigureRestDocs
 class NewsControllerV1Test(
     private val mockMvc: MockMvc,
     private val objectMapper: ObjectMapper,
-    @MockkBean
     private val newsQueryService: NewsQueryService,
-    @MockkBean
     private val newsCommandService: NewsCommandService,
-) : DescribeSpec({
+) : ControllerTestSpec({
 
     describe("GET /api/v1/news/{newsId}") {
         context("유효한 요청이 전달되면") {

--- a/src/test/kotlin/kr/galaxyhub/sc/api/v1/translation/TranslationControllerV1Test.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/api/v1/translation/TranslationControllerV1Test.kt
@@ -1,8 +1,6 @@
 package kr.galaxyhub.sc.api.v1.translation
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.ninjasquad.springmockk.MockkBean
-import io.kotest.core.spec.style.DescribeSpec
 import io.mockk.every
 import java.util.UUID
 import kr.galaxyhub.sc.api.support.ENUM
@@ -13,27 +11,22 @@ import kr.galaxyhub.sc.api.support.docPost
 import kr.galaxyhub.sc.api.support.pathMeans
 import kr.galaxyhub.sc.api.support.type
 import kr.galaxyhub.sc.api.v1.translation.dto.TranslationRequest
+import kr.galaxyhub.sc.config.spec.ControllerTestSpec
 import kr.galaxyhub.sc.news.domain.Language
 import kr.galaxyhub.sc.translation.application.TranslationCommandService
 import kr.galaxyhub.sc.translation.application.TranslationQueryService
 import kr.galaxyhub.sc.translation.application.dto.TranslationResponse
 import kr.galaxyhub.sc.translation.domain.TranslationStatus
 import kr.galaxyhub.sc.translation.domain.TranslatorProvider
-import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.MockMvc
 
-@WebMvcTest(TranslationControllerV1::class)
-@AutoConfigureRestDocs
 class TranslationControllerV1Test(
     private val mockMvc: MockMvc,
     private val objectMapper: ObjectMapper,
-    @MockkBean
     private val translationCommandService: TranslationCommandService,
-    @MockkBean
     private val translationQueryService: TranslationQueryService,
-) : DescribeSpec({
+) : ControllerTestSpec({
 
     describe("POST /api/v1/translation/{newsId}") {
         context("유효한 요청이 전달되면") {

--- a/src/test/kotlin/kr/galaxyhub/sc/config/spec/ControllerTestSpec.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/spec/ControllerTestSpec.kt
@@ -1,0 +1,35 @@
+package kr.galaxyhub.sc.config.spec
+
+import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.core.test.TestCase
+import io.kotest.core.test.TestResult
+import io.mockk.clearAllMocks
+import io.mockk.mockkClass
+import org.junit.platform.commons.util.ClassFilter
+import org.junit.platform.commons.util.ReflectionUtils
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory
+import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.stereotype.Service
+
+@Import(MockServiceBeanFactoryPostProcessor::class)
+@WebMvcTest
+@AutoConfigureRestDocs
+abstract class ControllerTestSpec(body: DescribeSpec.() -> Unit = {}) : DescribeSpec(body) {
+
+    override suspend fun afterEach(testCase: TestCase, result: TestResult) {
+        clearAllMocks()
+    }
+}
+
+class MockServiceBeanFactoryPostProcessor : BeanFactoryPostProcessor {
+
+    override fun postProcessBeanFactory(beanFactory: ConfigurableListableBeanFactory) {
+        val classFilter = ClassFilter.of { it.isAnnotationPresent(Service::class.java) }
+        ReflectionUtils.findAllClassesInPackage("kr.galaxyhub.sc", classFilter).forEach {
+            beanFactory.registerSingleton(it.simpleName, mockkClass(it.kotlin))
+        }
+    }
+}


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #78

## PR 세부 내용

`DescribeSpec`을 상속한 `ControllerTestSpec`을 만들어서, Controller 테스트에 적용하여, Application Context를 재활용 하도록 하였습니다!
이 경우, Controller 클래스가 의존하는 `Service` 클래스를 모두 빈으로 등록해야 하는 노가다 과정이 필요한데, 이 과정은 `BeanFactoryPostProcessor`를 사용하여 패키지 내 `@Service` 어노테이션이 붙은 클래스를 목으로 만들어 자동화 하였습니다!
