### PR TITLE
fix: Testcontainers 사용 시 버그 수정 (#82)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,7 @@ val mockkVersion = "1.13.4"
 val springMockkVersion = "4.0.2"
 val testcontainersVersion = "1.19.3"
 val kotestVersion = "5.7.2"
-val kotestExtensionTestcontainers = "2.0.2"
-val kotestExtensionSpring = "1.1.3"
+val kotestExtensionSpringVersion = "1.1.3"
 
 dependencies {
     // Spring
@@ -90,13 +89,12 @@ dependencies {
     testImplementation("com.ninja-squad:springmockk:$springMockkVersion")
 
     // Testcontainers
-    testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
+    testImplementation("org.testcontainers:testcontainers")
 
     // Kotest
     testImplementation("io.kotest:kotest-runner-junit5:$kotestVersion")
     testImplementation("io.kotest:kotest-assertions-core:$kotestVersion")
-    testImplementation("io.kotest.extensions:kotest-extensions-testcontainers:$kotestExtensionTestcontainers")
-    testImplementation("io.kotest.extensions:kotest-extensions-spring:$kotestExtensionSpring")
+    testImplementation("io.kotest.extensions:kotest-extensions-spring:$kotestExtensionSpringVersion")
 
     // Mock Web Server
     testImplementation("com.squareup.okhttp3:mockwebserver")

--- a/src/test/kotlin/kr/galaxyhub/sc/config/EnableTestcontianers.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/EnableTestcontianers.kt
@@ -1,0 +1,5 @@
+package kr.galaxyhub.sc.config
+
+@Target(AnnotationTarget.CLASS)
+@Retention(AnnotationRetention.RUNTIME)
+annotation class EnableTestcontianers

--- a/src/test/kotlin/kr/galaxyhub/sc/config/KotestProjectConfig.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/KotestProjectConfig.kt
@@ -1,9 +1,0 @@
-package kr.galaxyhub.sc.config
-
-import io.kotest.core.config.AbstractProjectConfig
-import io.kotest.extensions.spring.SpringExtension
-
-class KotestProjectConfig : AbstractProjectConfig() {
-
-    override fun extensions() = listOf(SpringExtension)
-}

--- a/src/test/kotlin/kr/galaxyhub/sc/config/TestContainerExtension.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/TestContainerExtension.kt
@@ -1,0 +1,43 @@
+package kr.galaxyhub.sc.config
+
+import io.kotest.core.extensions.ProjectExtension
+import io.kotest.core.project.ProjectContext
+import io.kotest.core.spec.AutoScan
+import io.kotest.mpp.hasAnnotation
+import java.io.File
+import kotlin.reflect.full.superclasses
+import org.slf4j.LoggerFactory
+import org.testcontainers.containers.DockerComposeContainer
+import org.testcontainers.containers.output.Slf4jLogConsumer
+import org.testcontainers.containers.wait.strategy.ShellStrategy
+
+@AutoScan
+class TestContainerExtension : ProjectExtension {
+
+    private var containers = mutableListOf<DockerComposeContainer<*>>()
+
+    override suspend fun interceptProject(context: ProjectContext, callback: suspend (ProjectContext) -> Unit) {
+        if (isTestcontianersEnable(context)) {
+            DockerComposeContainer(File("src/test/resources/docker-compose.yml")).apply {
+                waitingFor(
+                    "test_mysql",
+                    ShellStrategy().withCommand("mysql -u'test' -p'1234' -e'select 1' && sleep 2")
+                )
+                withLogConsumer("test_mysql", Slf4jLogConsumer(LoggerFactory.getLogger(javaClass)))
+                start()
+            }.also {
+                containers.add(it)
+            }
+        }
+        callback(context)
+        containers.forEach { it.stop() }
+    }
+
+    private fun isTestcontianersEnable(context: ProjectContext): Boolean {
+        val hasAnnotationItself = context.suite.specs.stream()
+            .anyMatch { it.kclass.hasAnnotation<EnableTestcontianers>() }
+        return if (hasAnnotationItself) true else context.suite.specs.stream()
+            .flatMap { it.kclass.superclasses.stream() }
+            .anyMatch { it.hasAnnotation<EnableTestcontianers>() }
+    }
+}

--- a/src/test/kotlin/kr/galaxyhub/sc/config/TestContainerExtension.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/TestContainerExtension.kt
@@ -14,7 +14,7 @@ import org.testcontainers.containers.wait.strategy.ShellStrategy
 @AutoScan
 class TestContainerExtension : ProjectExtension {
 
-    private var containers = mutableListOf<DockerComposeContainer<*>>()
+    private val containers = mutableListOf<DockerComposeContainer<*>>()
 
     override suspend fun interceptProject(context: ProjectContext, callback: suspend (ProjectContext) -> Unit) {
         if (isTestcontianersEnable(context)) {

--- a/src/test/kotlin/kr/galaxyhub/sc/config/spec/ControllerTestSpec.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/spec/ControllerTestSpec.kt
@@ -3,6 +3,7 @@ package kr.galaxyhub.sc.config.spec
 import io.kotest.core.spec.style.DescribeSpec
 import io.kotest.core.test.TestCase
 import io.kotest.core.test.TestResult
+import io.kotest.extensions.spring.SpringExtension
 import io.mockk.clearAllMocks
 import io.mockk.mockkClass
 import org.junit.platform.commons.util.ClassFilter
@@ -18,6 +19,8 @@ import org.springframework.stereotype.Service
 @WebMvcTest
 @AutoConfigureRestDocs
 abstract class ControllerTestSpec(body: DescribeSpec.() -> Unit = {}) : DescribeSpec(body) {
+
+    override fun extensions() = listOf(SpringExtension)
 
     override suspend fun afterEach(testCase: TestCase, result: TestResult) {
         clearAllMocks()

--- a/src/test/kotlin/kr/galaxyhub/sc/config/spec/IntegrationSpec.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/spec/IntegrationSpec.kt
@@ -1,27 +1,9 @@
 package kr.galaxyhub.sc.config.spec
 
-import io.kotest.core.extensions.install
 import io.kotest.core.spec.style.DescribeSpec
-import io.kotest.extensions.testcontainers.ContainerLifecycleMode
-import io.kotest.extensions.testcontainers.DockerComposeContainerExtension
-import java.io.File
-import org.slf4j.LoggerFactory
+import kr.galaxyhub.sc.config.EnableTestcontianers
 import org.springframework.boot.test.context.SpringBootTest
-import org.testcontainers.containers.output.Slf4jLogConsumer
-import org.testcontainers.containers.wait.strategy.ShellStrategy
 
 @SpringBootTest
-abstract class IntegrationSpec(body: DescribeSpec.() -> Unit = {}) : DescribeSpec(body) {
-
-    private val log = LoggerFactory.getLogger(javaClass)
-
-    init {
-        install(DockerComposeContainerExtension(File("src/test/resources/docker-compose.yml"), ContainerLifecycleMode.Project))
-            .apply {
-                waitingFor("test_mysql", ShellStrategy().withCommand("mysql -u'test' -p'1234' -e'select 1' && sleep 2"))
-                withLogConsumer("test_mysql", Slf4jLogConsumer(log))
-            }.apply {
-                start()
-            }
-    }
-}
+@EnableTestcontianers
+abstract class IntegrationSpec(body: DescribeSpec.() -> Unit = {}) : DescribeSpec(body)

--- a/src/test/kotlin/kr/galaxyhub/sc/config/spec/IntegrationSpec.kt
+++ b/src/test/kotlin/kr/galaxyhub/sc/config/spec/IntegrationSpec.kt
@@ -1,9 +1,13 @@
 package kr.galaxyhub.sc.config.spec
 
 import io.kotest.core.spec.style.DescribeSpec
+import io.kotest.extensions.spring.SpringExtension
 import kr.galaxyhub.sc.config.EnableTestcontianers
 import org.springframework.boot.test.context.SpringBootTest
 
 @SpringBootTest
 @EnableTestcontianers
-abstract class IntegrationSpec(body: DescribeSpec.() -> Unit = {}) : DescribeSpec(body)
+abstract class IntegrationSpec(body: DescribeSpec.() -> Unit = {}) : DescribeSpec(body) {
+
+    override fun extensions() = listOf(SpringExtension)
+}

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -1,6 +1,4 @@
-version: "3.3"
-volumes:
-  mysql_data: { }
+version: "3"
 services:
   test_mysql:
     image: mysql:8.0.33
@@ -8,14 +6,10 @@ services:
       - "13306:3306"
     environment:
       TZ: Asia/Seoul
+      MYSQL_DATABASE: test
+      MYSQL_ROOT_PASSWORD: 1234
       MYSQL_USER: test
       MYSQL_PASSWORD: 1234
-      MYSQL_ROOT_PASSWORD: 1234
-      MYSQL_DATABASE: test
-    volumes:
-      - mysql_data:/var/lib/mysql/
-      - ./sql:/docker-entrypoint-initdb.d
     command:
-      - "--character-set-server=utf8mb4"
-      - "--collation-server=utf8mb4_unicode_ci"
-      - "--skip-character-set-client-handshake"
+      - --character-set-server=utf8mb4
+      - --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
<!--
PR 제목 컨벤션
feat: ~~(#issueNum)
refactor: ~~(#issueNum)
-->

## 관련 이슈

- close #82

## PR 세부 내용

#82 이슈에서 Spring Bean 생성자 주입을 받을 때 문제가 생긴다고 했지만, 통합 테스트를 여러 개 만들어도 문제가 생깁니다.

`IntegrationSpec`을 상속했을 때 `DockerComposeContainerExtension` 인스턴스가 상속 받은 클래스 만큼 생성되는데, 이때 중복적으로 컨테이너 실행되므로, 컨테이너 간 충돌이 발생하여 테스트가 실패합니다.

따라서 82번 이슈와 함께 해결하기 위해 `ProjectExtension`을 상속한 Extension을 만들었고, `@Autoscan` 어노테이션으로 모든 테스트마다 Extension이 등록되도록 하였습니다.

해당 Extension은 실행된 테스트 클래스(Spec) 중 `@EnableTestcontianers` 어노테이션이 붙어있는 테스트가 발견되면 컨테이너를 실행하고, 없으면 실행하지 않도록 하여, 테스트 컨테이너가 필요 없는 테스트에서 테스트 컨테이너를 실행하느라 시간이 소요되는 것을 막았습니다.

따라서 통합 테스트가 필요한 경우 `IntegrationSpec`을 상속하여 사용하면 되고, 통합 테스트는 아니지만 DB 의존이 필요한 테스트는 `@EnableTestcontianers` 어노테이션을 붙여서 사용하면 됩니다.
